### PR TITLE
Add support for Router Group deletion

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ type Client interface {
 	RouterGroupWithName(string) (models.RouterGroup, error)
 	UpdateRouterGroup(models.RouterGroup) error
 	CreateRouterGroup(models.RouterGroup) error
+	DeleteRouterGroup(models.RouterGroup) error
 	UpsertTcpRouteMappings([]models.TcpRouteMapping) error
 	DeleteTcpRouteMappings([]models.TcpRouteMapping) error
 	TcpRouteMappings() ([]models.TcpRouteMapping, error)
@@ -103,6 +104,10 @@ func (c *client) UpdateRouterGroup(group models.RouterGroup) error {
 
 func (c *client) CreateRouterGroup(group models.RouterGroup) error {
 	return c.doRequest(CreateRouterGroup, nil, nil, group, nil)
+}
+
+func (c *client) DeleteRouterGroup(group models.RouterGroup) error {
+	return c.doRequest(DeleteRouterGroup, rata.Params{"guid": group.Guid}, nil, nil, nil)
 }
 
 func (c *client) RouterGroups() ([]models.RouterGroup, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -877,6 +877,56 @@ var _ = Describe("Client", func() {
 		})
 	})
 
+	Context("DeleteRouterGroup", func() {
+		var (
+			err          error
+			routerGroup1 models.RouterGroup
+		)
+
+		BeforeEach(func() {
+			routerGroup1 = models.RouterGroup{
+				Guid:            DefaultRouterGroupGuid,
+				Name:            DefaultRouterGroupName,
+				Type:            DefaultRouterGroupType,
+				ReservablePorts: "4000-5000",
+			}
+		})
+
+		Context("when the server returns a valid response", func() {
+			BeforeEach(func() {
+				data, _ := json.Marshal([]models.RouterGroup{routerGroup1})
+
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", fmt.Sprintf("%s/%s", ROUTER_GROUPS_API_URL, routerGroup1.Guid)),
+						ghttp.RespondWith(http.StatusNoContent, data),
+					),
+				)
+			})
+
+			It("Sends a DeleteRouterGroup request to the server", func() {
+				err = client.DeleteRouterGroup(routerGroup1)
+				Expect(server.ReceivedRequests()).Should(HaveLen(1))
+			})
+		})
+
+		Context("When the server returns an error", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("DELETE", fmt.Sprintf("%s/%s", ROUTER_GROUPS_API_URL, routerGroup1.Guid)),
+						ghttp.RespondWith(http.StatusInternalServerError, nil),
+					),
+				)
+			})
+
+			It("returns an error", func() {
+				err = client.DeleteRouterGroup(routerGroup1)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
 	Context("CreateRouterGroup", func() {
 
 		var (

--- a/cmd/routing-api/api_test.go
+++ b/cmd/routing-api/api_test.go
@@ -534,6 +534,26 @@ var _ = Describe("Routes API", func() {
 					createRouterGroup()
 				})
 			})
+
+			Context("DELETE", func() {
+				It("deletes router groups", func() {
+					var routerGroups models.RouterGroups
+					Eventually(func() error {
+						var err error
+						routerGroups, err = client.RouterGroups()
+						return err
+					}, "30s", "1s").ShouldNot(HaveOccurred(), "Failed to connect to Routing API server after 30s.")
+					Expect(len(routerGroups)).To(Equal(1))
+					routerGroup := routerGroups[0]
+
+					err := client.DeleteRouterGroup(routerGroup)
+					Expect(err).NotTo(HaveOccurred())
+
+					routerGroups, err = client.RouterGroups()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(len(routerGroups)).To(Equal(0))
+				})
+			})
 		})
 	}
 

--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -359,6 +359,7 @@ func apiHandler(cfg config.Config, uaaClient uaaclient.Client, database db.DB, s
 		routing_api.ListRouterGroups:      route(routerGroupsHandler.ListRouterGroups),
 		routing_api.CreateRouterGroup:     route(routerGroupsHandler.CreateRouterGroup),
 		routing_api.UpdateRouterGroup:     route(routerGroupsHandler.UpdateRouterGroup),
+		routing_api.DeleteRouterGroup:     route(routerGroupsHandler.DeleteRouterGroup),
 		routing_api.UpsertTcpRouteMapping: route(tcpMappingsHandler.Upsert),
 		routing_api.DeleteTcpRouteMapping: route(tcpMappingsHandler.Delete),
 		routing_api.ListTcpRouteMapping:   route(tcpMappingsHandler.List),

--- a/db/fakes/fake_client.go
+++ b/db/fakes/fake_client.go
@@ -2,10 +2,10 @@
 package fakes
 
 import (
-	sql "database/sql"
-	sync "sync"
+	"database/sql"
+	"sync"
 
-	db "code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/db"
 )
 
 type FakeClient struct {

--- a/db/fakes/fake_db.go
+++ b/db/fakes/fake_db.go
@@ -2,11 +2,11 @@
 package fakes
 
 import (
-	context "context"
-	sync "sync"
+	"context"
+	"sync"
 
-	db "code.cloudfoundry.org/routing-api/db"
-	models "code.cloudfoundry.org/routing-api/models"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
 )
 
 type FakeDB struct {
@@ -23,6 +23,17 @@ type FakeDB struct {
 		result1 error
 	}
 	deleteRouteReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteRouterGroupStub        func(string) error
+	deleteRouterGroupMutex       sync.RWMutex
+	deleteRouterGroupArgsForCall []struct {
+		arg1 string
+	}
+	deleteRouterGroupReturns struct {
+		result1 error
+	}
+	deleteRouterGroupReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DeleteTcpRouteMappingStub        func(models.TcpRouteMapping) error
@@ -259,6 +270,66 @@ func (fake *FakeDB) DeleteRouteReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteRouteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDB) DeleteRouterGroup(arg1 string) error {
+	fake.deleteRouterGroupMutex.Lock()
+	ret, specificReturn := fake.deleteRouterGroupReturnsOnCall[len(fake.deleteRouterGroupArgsForCall)]
+	fake.deleteRouterGroupArgsForCall = append(fake.deleteRouterGroupArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeleteRouterGroup", []interface{}{arg1})
+	fake.deleteRouterGroupMutex.Unlock()
+	if fake.DeleteRouterGroupStub != nil {
+		return fake.DeleteRouterGroupStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteRouterGroupReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeDB) DeleteRouterGroupCallCount() int {
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
+	return len(fake.deleteRouterGroupArgsForCall)
+}
+
+func (fake *FakeDB) DeleteRouterGroupCalls(stub func(string) error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = stub
+}
+
+func (fake *FakeDB) DeleteRouterGroupArgsForCall(i int) string {
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
+	argsForCall := fake.deleteRouterGroupArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeDB) DeleteRouterGroupReturns(result1 error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = nil
+	fake.deleteRouterGroupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeDB) DeleteRouterGroupReturnsOnCall(i int, result1 error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = nil
+	if fake.deleteRouterGroupReturnsOnCall == nil {
+		fake.deleteRouterGroupReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteRouterGroupReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1028,6 +1099,8 @@ func (fake *FakeDB) Invocations() map[string][][]interface{} {
 	defer fake.cancelWatchesMutex.RUnlock()
 	fake.deleteRouteMutex.RLock()
 	defer fake.deleteRouteMutex.RUnlock()
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
 	fake.deleteTcpRouteMappingMutex.RLock()
 	defer fake.deleteTcpRouteMappingMutex.RUnlock()
 	fake.lockRouterGroupReadsMutex.RLock()

--- a/db/fakes/fake_mysql_adapter.go
+++ b/db/fakes/fake_mysql_adapter.go
@@ -2,8 +2,8 @@
 package fakes
 
 import (
-	tls "crypto/tls"
-	sync "sync"
+	"crypto/tls"
+	"sync"
 )
 
 type MySQLAdapter struct {

--- a/fake_routing_api/fake_client.go
+++ b/fake_routing_api/fake_client.go
@@ -9,32 +9,27 @@ import (
 )
 
 type FakeClient struct {
-	SetTokenStub        func(string)
-	setTokenMutex       sync.RWMutex
-	setTokenArgsForCall []struct {
-		arg1 string
+	CreateRouterGroupStub        func(models.RouterGroup) error
+	createRouterGroupMutex       sync.RWMutex
+	createRouterGroupArgsForCall []struct {
+		arg1 models.RouterGroup
 	}
-	UpsertRoutesStub        func([]models.Route) error
-	upsertRoutesMutex       sync.RWMutex
-	upsertRoutesArgsForCall []struct {
-		arg1 []models.Route
-	}
-	upsertRoutesReturns struct {
+	createRouterGroupReturns struct {
 		result1 error
 	}
-	upsertRoutesReturnsOnCall map[int]struct {
+	createRouterGroupReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RoutesStub        func() ([]models.Route, error)
-	routesMutex       sync.RWMutex
-	routesArgsForCall []struct{}
-	routesReturns     struct {
-		result1 []models.Route
-		result2 error
+	DeleteRouterGroupStub        func(models.RouterGroup) error
+	deleteRouterGroupMutex       sync.RWMutex
+	deleteRouterGroupArgsForCall []struct {
+		arg1 models.RouterGroup
 	}
-	routesReturnsOnCall map[int]struct {
-		result1 []models.Route
-		result2 error
+	deleteRouterGroupReturns struct {
+		result1 error
+	}
+	deleteRouterGroupReturnsOnCall map[int]struct {
+		result1 error
 	}
 	DeleteRoutesStub        func([]models.Route) error
 	deleteRoutesMutex       sync.RWMutex
@@ -47,15 +42,28 @@ type FakeClient struct {
 	deleteRoutesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RouterGroupsStub        func() ([]models.RouterGroup, error)
-	routerGroupsMutex       sync.RWMutex
-	routerGroupsArgsForCall []struct{}
-	routerGroupsReturns     struct {
-		result1 []models.RouterGroup
+	DeleteTcpRouteMappingsStub        func([]models.TcpRouteMapping) error
+	deleteTcpRouteMappingsMutex       sync.RWMutex
+	deleteTcpRouteMappingsArgsForCall []struct {
+		arg1 []models.TcpRouteMapping
+	}
+	deleteTcpRouteMappingsReturns struct {
+		result1 error
+	}
+	deleteTcpRouteMappingsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	FilteredTcpRouteMappingsStub        func([]string) ([]models.TcpRouteMapping, error)
+	filteredTcpRouteMappingsMutex       sync.RWMutex
+	filteredTcpRouteMappingsArgsForCall []struct {
+		arg1 []string
+	}
+	filteredTcpRouteMappingsReturns struct {
+		result1 []models.TcpRouteMapping
 		result2 error
 	}
-	routerGroupsReturnsOnCall map[int]struct {
-		result1 []models.RouterGroup
+	filteredTcpRouteMappingsReturnsOnCall map[int]struct {
+		result1 []models.TcpRouteMapping
 		result2 error
 	}
 	RouterGroupWithNameStub        func(string) (models.RouterGroup, error)
@@ -71,6 +79,97 @@ type FakeClient struct {
 		result1 models.RouterGroup
 		result2 error
 	}
+	RouterGroupsStub        func() ([]models.RouterGroup, error)
+	routerGroupsMutex       sync.RWMutex
+	routerGroupsArgsForCall []struct {
+	}
+	routerGroupsReturns struct {
+		result1 []models.RouterGroup
+		result2 error
+	}
+	routerGroupsReturnsOnCall map[int]struct {
+		result1 []models.RouterGroup
+		result2 error
+	}
+	RoutesStub        func() ([]models.Route, error)
+	routesMutex       sync.RWMutex
+	routesArgsForCall []struct {
+	}
+	routesReturns struct {
+		result1 []models.Route
+		result2 error
+	}
+	routesReturnsOnCall map[int]struct {
+		result1 []models.Route
+		result2 error
+	}
+	SetTokenStub        func(string)
+	setTokenMutex       sync.RWMutex
+	setTokenArgsForCall []struct {
+		arg1 string
+	}
+	SubscribeToEventsStub        func() (routing_api.EventSource, error)
+	subscribeToEventsMutex       sync.RWMutex
+	subscribeToEventsArgsForCall []struct {
+	}
+	subscribeToEventsReturns struct {
+		result1 routing_api.EventSource
+		result2 error
+	}
+	subscribeToEventsReturnsOnCall map[int]struct {
+		result1 routing_api.EventSource
+		result2 error
+	}
+	SubscribeToEventsWithMaxRetriesStub        func(uint16) (routing_api.EventSource, error)
+	subscribeToEventsWithMaxRetriesMutex       sync.RWMutex
+	subscribeToEventsWithMaxRetriesArgsForCall []struct {
+		arg1 uint16
+	}
+	subscribeToEventsWithMaxRetriesReturns struct {
+		result1 routing_api.EventSource
+		result2 error
+	}
+	subscribeToEventsWithMaxRetriesReturnsOnCall map[int]struct {
+		result1 routing_api.EventSource
+		result2 error
+	}
+	SubscribeToTcpEventsStub        func() (routing_api.TcpEventSource, error)
+	subscribeToTcpEventsMutex       sync.RWMutex
+	subscribeToTcpEventsArgsForCall []struct {
+	}
+	subscribeToTcpEventsReturns struct {
+		result1 routing_api.TcpEventSource
+		result2 error
+	}
+	subscribeToTcpEventsReturnsOnCall map[int]struct {
+		result1 routing_api.TcpEventSource
+		result2 error
+	}
+	SubscribeToTcpEventsWithMaxRetriesStub        func(uint16) (routing_api.TcpEventSource, error)
+	subscribeToTcpEventsWithMaxRetriesMutex       sync.RWMutex
+	subscribeToTcpEventsWithMaxRetriesArgsForCall []struct {
+		arg1 uint16
+	}
+	subscribeToTcpEventsWithMaxRetriesReturns struct {
+		result1 routing_api.TcpEventSource
+		result2 error
+	}
+	subscribeToTcpEventsWithMaxRetriesReturnsOnCall map[int]struct {
+		result1 routing_api.TcpEventSource
+		result2 error
+	}
+	TcpRouteMappingsStub        func() ([]models.TcpRouteMapping, error)
+	tcpRouteMappingsMutex       sync.RWMutex
+	tcpRouteMappingsArgsForCall []struct {
+	}
+	tcpRouteMappingsReturns struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}
+	tcpRouteMappingsReturnsOnCall map[int]struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}
 	UpdateRouterGroupStub        func(models.RouterGroup) error
 	updateRouterGroupMutex       sync.RWMutex
 	updateRouterGroupArgsForCall []struct {
@@ -82,15 +181,15 @@ type FakeClient struct {
 	updateRouterGroupReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateRouterGroupStub        func(models.RouterGroup) error
-	createRouterGroupMutex       sync.RWMutex
-	createRouterGroupArgsForCall []struct {
-		arg1 models.RouterGroup
+	UpsertRoutesStub        func([]models.Route) error
+	upsertRoutesMutex       sync.RWMutex
+	upsertRoutesArgsForCall []struct {
+		arg1 []models.Route
 	}
-	createRouterGroupReturns struct {
+	upsertRoutesReturns struct {
 		result1 error
 	}
-	createRouterGroupReturnsOnCall map[int]struct {
+	upsertRoutesReturnsOnCall map[int]struct {
 		result1 error
 	}
 	UpsertTcpRouteMappingsStub        func([]models.TcpRouteMapping) error
@@ -104,211 +203,128 @@ type FakeClient struct {
 	upsertTcpRouteMappingsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DeleteTcpRouteMappingsStub        func([]models.TcpRouteMapping) error
-	deleteTcpRouteMappingsMutex       sync.RWMutex
-	deleteTcpRouteMappingsArgsForCall []struct {
-		arg1 []models.TcpRouteMapping
-	}
-	deleteTcpRouteMappingsReturns struct {
-		result1 error
-	}
-	deleteTcpRouteMappingsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	TcpRouteMappingsStub        func() ([]models.TcpRouteMapping, error)
-	tcpRouteMappingsMutex       sync.RWMutex
-	tcpRouteMappingsArgsForCall []struct{}
-	tcpRouteMappingsReturns     struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}
-	tcpRouteMappingsReturnsOnCall map[int]struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}
-	FilteredTcpRouteMappingsStub        func([]string) ([]models.TcpRouteMapping, error)
-	filteredTcpRouteMappingsMutex       sync.RWMutex
-	filteredTcpRouteMappingsArgsForCall []struct {
-		arg1 []string
-	}
-	filteredTcpRouteMappingsReturns struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}
-	filteredTcpRouteMappingsReturnsOnCall map[int]struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}
-	SubscribeToEventsStub        func() (routing_api.EventSource, error)
-	subscribeToEventsMutex       sync.RWMutex
-	subscribeToEventsArgsForCall []struct{}
-	subscribeToEventsReturns     struct {
-		result1 routing_api.EventSource
-		result2 error
-	}
-	subscribeToEventsReturnsOnCall map[int]struct {
-		result1 routing_api.EventSource
-		result2 error
-	}
-	SubscribeToEventsWithMaxRetriesStub        func(retries uint16) (routing_api.EventSource, error)
-	subscribeToEventsWithMaxRetriesMutex       sync.RWMutex
-	subscribeToEventsWithMaxRetriesArgsForCall []struct {
-		retries uint16
-	}
-	subscribeToEventsWithMaxRetriesReturns struct {
-		result1 routing_api.EventSource
-		result2 error
-	}
-	subscribeToEventsWithMaxRetriesReturnsOnCall map[int]struct {
-		result1 routing_api.EventSource
-		result2 error
-	}
-	SubscribeToTcpEventsStub        func() (routing_api.TcpEventSource, error)
-	subscribeToTcpEventsMutex       sync.RWMutex
-	subscribeToTcpEventsArgsForCall []struct{}
-	subscribeToTcpEventsReturns     struct {
-		result1 routing_api.TcpEventSource
-		result2 error
-	}
-	subscribeToTcpEventsReturnsOnCall map[int]struct {
-		result1 routing_api.TcpEventSource
-		result2 error
-	}
-	SubscribeToTcpEventsWithMaxRetriesStub        func(retries uint16) (routing_api.TcpEventSource, error)
-	subscribeToTcpEventsWithMaxRetriesMutex       sync.RWMutex
-	subscribeToTcpEventsWithMaxRetriesArgsForCall []struct {
-		retries uint16
-	}
-	subscribeToTcpEventsWithMaxRetriesReturns struct {
-		result1 routing_api.TcpEventSource
-		result2 error
-	}
-	subscribeToTcpEventsWithMaxRetriesReturnsOnCall map[int]struct {
-		result1 routing_api.TcpEventSource
-		result2 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) SetToken(arg1 string) {
-	fake.setTokenMutex.Lock()
-	fake.setTokenArgsForCall = append(fake.setTokenArgsForCall, struct {
-		arg1 string
+func (fake *FakeClient) CreateRouterGroup(arg1 models.RouterGroup) error {
+	fake.createRouterGroupMutex.Lock()
+	ret, specificReturn := fake.createRouterGroupReturnsOnCall[len(fake.createRouterGroupArgsForCall)]
+	fake.createRouterGroupArgsForCall = append(fake.createRouterGroupArgsForCall, struct {
+		arg1 models.RouterGroup
 	}{arg1})
-	fake.recordInvocation("SetToken", []interface{}{arg1})
-	fake.setTokenMutex.Unlock()
-	if fake.SetTokenStub != nil {
-		fake.SetTokenStub(arg1)
-	}
-}
-
-func (fake *FakeClient) SetTokenCallCount() int {
-	fake.setTokenMutex.RLock()
-	defer fake.setTokenMutex.RUnlock()
-	return len(fake.setTokenArgsForCall)
-}
-
-func (fake *FakeClient) SetTokenArgsForCall(i int) string {
-	fake.setTokenMutex.RLock()
-	defer fake.setTokenMutex.RUnlock()
-	return fake.setTokenArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) UpsertRoutes(arg1 []models.Route) error {
-	var arg1Copy []models.Route
-	if arg1 != nil {
-		arg1Copy = make([]models.Route, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.upsertRoutesMutex.Lock()
-	ret, specificReturn := fake.upsertRoutesReturnsOnCall[len(fake.upsertRoutesArgsForCall)]
-	fake.upsertRoutesArgsForCall = append(fake.upsertRoutesArgsForCall, struct {
-		arg1 []models.Route
-	}{arg1Copy})
-	fake.recordInvocation("UpsertRoutes", []interface{}{arg1Copy})
-	fake.upsertRoutesMutex.Unlock()
-	if fake.UpsertRoutesStub != nil {
-		return fake.UpsertRoutesStub(arg1)
+	fake.recordInvocation("CreateRouterGroup", []interface{}{arg1})
+	fake.createRouterGroupMutex.Unlock()
+	if fake.CreateRouterGroupStub != nil {
+		return fake.CreateRouterGroupStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.upsertRoutesReturns.result1
+	fakeReturns := fake.createRouterGroupReturns
+	return fakeReturns.result1
 }
 
-func (fake *FakeClient) UpsertRoutesCallCount() int {
-	fake.upsertRoutesMutex.RLock()
-	defer fake.upsertRoutesMutex.RUnlock()
-	return len(fake.upsertRoutesArgsForCall)
+func (fake *FakeClient) CreateRouterGroupCallCount() int {
+	fake.createRouterGroupMutex.RLock()
+	defer fake.createRouterGroupMutex.RUnlock()
+	return len(fake.createRouterGroupArgsForCall)
 }
 
-func (fake *FakeClient) UpsertRoutesArgsForCall(i int) []models.Route {
-	fake.upsertRoutesMutex.RLock()
-	defer fake.upsertRoutesMutex.RUnlock()
-	return fake.upsertRoutesArgsForCall[i].arg1
+func (fake *FakeClient) CreateRouterGroupCalls(stub func(models.RouterGroup) error) {
+	fake.createRouterGroupMutex.Lock()
+	defer fake.createRouterGroupMutex.Unlock()
+	fake.CreateRouterGroupStub = stub
 }
 
-func (fake *FakeClient) UpsertRoutesReturns(result1 error) {
-	fake.UpsertRoutesStub = nil
-	fake.upsertRoutesReturns = struct {
+func (fake *FakeClient) CreateRouterGroupArgsForCall(i int) models.RouterGroup {
+	fake.createRouterGroupMutex.RLock()
+	defer fake.createRouterGroupMutex.RUnlock()
+	argsForCall := fake.createRouterGroupArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) CreateRouterGroupReturns(result1 error) {
+	fake.createRouterGroupMutex.Lock()
+	defer fake.createRouterGroupMutex.Unlock()
+	fake.CreateRouterGroupStub = nil
+	fake.createRouterGroupReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeClient) UpsertRoutesReturnsOnCall(i int, result1 error) {
-	fake.UpsertRoutesStub = nil
-	if fake.upsertRoutesReturnsOnCall == nil {
-		fake.upsertRoutesReturnsOnCall = make(map[int]struct {
+func (fake *FakeClient) CreateRouterGroupReturnsOnCall(i int, result1 error) {
+	fake.createRouterGroupMutex.Lock()
+	defer fake.createRouterGroupMutex.Unlock()
+	fake.CreateRouterGroupStub = nil
+	if fake.createRouterGroupReturnsOnCall == nil {
+		fake.createRouterGroupReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.upsertRoutesReturnsOnCall[i] = struct {
+	fake.createRouterGroupReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *FakeClient) Routes() ([]models.Route, error) {
-	fake.routesMutex.Lock()
-	ret, specificReturn := fake.routesReturnsOnCall[len(fake.routesArgsForCall)]
-	fake.routesArgsForCall = append(fake.routesArgsForCall, struct{}{})
-	fake.recordInvocation("Routes", []interface{}{})
-	fake.routesMutex.Unlock()
-	if fake.RoutesStub != nil {
-		return fake.RoutesStub()
+func (fake *FakeClient) DeleteRouterGroup(arg1 models.RouterGroup) error {
+	fake.deleteRouterGroupMutex.Lock()
+	ret, specificReturn := fake.deleteRouterGroupReturnsOnCall[len(fake.deleteRouterGroupArgsForCall)]
+	fake.deleteRouterGroupArgsForCall = append(fake.deleteRouterGroupArgsForCall, struct {
+		arg1 models.RouterGroup
+	}{arg1})
+	fake.recordInvocation("DeleteRouterGroup", []interface{}{arg1})
+	fake.deleteRouterGroupMutex.Unlock()
+	if fake.DeleteRouterGroupStub != nil {
+		return fake.DeleteRouterGroupStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fake.routesReturns.result1, fake.routesReturns.result2
+	fakeReturns := fake.deleteRouterGroupReturns
+	return fakeReturns.result1
 }
 
-func (fake *FakeClient) RoutesCallCount() int {
-	fake.routesMutex.RLock()
-	defer fake.routesMutex.RUnlock()
-	return len(fake.routesArgsForCall)
+func (fake *FakeClient) DeleteRouterGroupCallCount() int {
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
+	return len(fake.deleteRouterGroupArgsForCall)
 }
 
-func (fake *FakeClient) RoutesReturns(result1 []models.Route, result2 error) {
-	fake.RoutesStub = nil
-	fake.routesReturns = struct {
-		result1 []models.Route
-		result2 error
-	}{result1, result2}
+func (fake *FakeClient) DeleteRouterGroupCalls(stub func(models.RouterGroup) error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = stub
 }
 
-func (fake *FakeClient) RoutesReturnsOnCall(i int, result1 []models.Route, result2 error) {
-	fake.RoutesStub = nil
-	if fake.routesReturnsOnCall == nil {
-		fake.routesReturnsOnCall = make(map[int]struct {
-			result1 []models.Route
-			result2 error
+func (fake *FakeClient) DeleteRouterGroupArgsForCall(i int) models.RouterGroup {
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
+	argsForCall := fake.deleteRouterGroupArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeleteRouterGroupReturns(result1 error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = nil
+	fake.deleteRouterGroupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteRouterGroupReturnsOnCall(i int, result1 error) {
+	fake.deleteRouterGroupMutex.Lock()
+	defer fake.deleteRouterGroupMutex.Unlock()
+	fake.DeleteRouterGroupStub = nil
+	if fake.deleteRouterGroupReturnsOnCall == nil {
+		fake.deleteRouterGroupReturnsOnCall = make(map[int]struct {
+			result1 error
 		})
 	}
-	fake.routesReturnsOnCall[i] = struct {
-		result1 []models.Route
-		result2 error
-	}{result1, result2}
+	fake.deleteRouterGroupReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeClient) DeleteRoutes(arg1 []models.Route) error {
@@ -330,7 +346,8 @@ func (fake *FakeClient) DeleteRoutes(arg1 []models.Route) error {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.deleteRoutesReturns.result1
+	fakeReturns := fake.deleteRoutesReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) DeleteRoutesCallCount() int {
@@ -339,13 +356,22 @@ func (fake *FakeClient) DeleteRoutesCallCount() int {
 	return len(fake.deleteRoutesArgsForCall)
 }
 
+func (fake *FakeClient) DeleteRoutesCalls(stub func([]models.Route) error) {
+	fake.deleteRoutesMutex.Lock()
+	defer fake.deleteRoutesMutex.Unlock()
+	fake.DeleteRoutesStub = stub
+}
+
 func (fake *FakeClient) DeleteRoutesArgsForCall(i int) []models.Route {
 	fake.deleteRoutesMutex.RLock()
 	defer fake.deleteRoutesMutex.RUnlock()
-	return fake.deleteRoutesArgsForCall[i].arg1
+	argsForCall := fake.deleteRoutesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) DeleteRoutesReturns(result1 error) {
+	fake.deleteRoutesMutex.Lock()
+	defer fake.deleteRoutesMutex.Unlock()
 	fake.DeleteRoutesStub = nil
 	fake.deleteRoutesReturns = struct {
 		result1 error
@@ -353,6 +379,8 @@ func (fake *FakeClient) DeleteRoutesReturns(result1 error) {
 }
 
 func (fake *FakeClient) DeleteRoutesReturnsOnCall(i int, result1 error) {
+	fake.deleteRoutesMutex.Lock()
+	defer fake.deleteRoutesMutex.Unlock()
 	fake.DeleteRoutesStub = nil
 	if fake.deleteRoutesReturnsOnCall == nil {
 		fake.deleteRoutesReturnsOnCall = make(map[int]struct {
@@ -360,249 +388,6 @@ func (fake *FakeClient) DeleteRoutesReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteRoutesReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) RouterGroups() ([]models.RouterGroup, error) {
-	fake.routerGroupsMutex.Lock()
-	ret, specificReturn := fake.routerGroupsReturnsOnCall[len(fake.routerGroupsArgsForCall)]
-	fake.routerGroupsArgsForCall = append(fake.routerGroupsArgsForCall, struct{}{})
-	fake.recordInvocation("RouterGroups", []interface{}{})
-	fake.routerGroupsMutex.Unlock()
-	if fake.RouterGroupsStub != nil {
-		return fake.RouterGroupsStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.routerGroupsReturns.result1, fake.routerGroupsReturns.result2
-}
-
-func (fake *FakeClient) RouterGroupsCallCount() int {
-	fake.routerGroupsMutex.RLock()
-	defer fake.routerGroupsMutex.RUnlock()
-	return len(fake.routerGroupsArgsForCall)
-}
-
-func (fake *FakeClient) RouterGroupsReturns(result1 []models.RouterGroup, result2 error) {
-	fake.RouterGroupsStub = nil
-	fake.routerGroupsReturns = struct {
-		result1 []models.RouterGroup
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) RouterGroupsReturnsOnCall(i int, result1 []models.RouterGroup, result2 error) {
-	fake.RouterGroupsStub = nil
-	if fake.routerGroupsReturnsOnCall == nil {
-		fake.routerGroupsReturnsOnCall = make(map[int]struct {
-			result1 []models.RouterGroup
-			result2 error
-		})
-	}
-	fake.routerGroupsReturnsOnCall[i] = struct {
-		result1 []models.RouterGroup
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) RouterGroupWithName(arg1 string) (models.RouterGroup, error) {
-	fake.routerGroupWithNameMutex.Lock()
-	ret, specificReturn := fake.routerGroupWithNameReturnsOnCall[len(fake.routerGroupWithNameArgsForCall)]
-	fake.routerGroupWithNameArgsForCall = append(fake.routerGroupWithNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("RouterGroupWithName", []interface{}{arg1})
-	fake.routerGroupWithNameMutex.Unlock()
-	if fake.RouterGroupWithNameStub != nil {
-		return fake.RouterGroupWithNameStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.routerGroupWithNameReturns.result1, fake.routerGroupWithNameReturns.result2
-}
-
-func (fake *FakeClient) RouterGroupWithNameCallCount() int {
-	fake.routerGroupWithNameMutex.RLock()
-	defer fake.routerGroupWithNameMutex.RUnlock()
-	return len(fake.routerGroupWithNameArgsForCall)
-}
-
-func (fake *FakeClient) RouterGroupWithNameArgsForCall(i int) string {
-	fake.routerGroupWithNameMutex.RLock()
-	defer fake.routerGroupWithNameMutex.RUnlock()
-	return fake.routerGroupWithNameArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) RouterGroupWithNameReturns(result1 models.RouterGroup, result2 error) {
-	fake.RouterGroupWithNameStub = nil
-	fake.routerGroupWithNameReturns = struct {
-		result1 models.RouterGroup
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) RouterGroupWithNameReturnsOnCall(i int, result1 models.RouterGroup, result2 error) {
-	fake.RouterGroupWithNameStub = nil
-	if fake.routerGroupWithNameReturnsOnCall == nil {
-		fake.routerGroupWithNameReturnsOnCall = make(map[int]struct {
-			result1 models.RouterGroup
-			result2 error
-		})
-	}
-	fake.routerGroupWithNameReturnsOnCall[i] = struct {
-		result1 models.RouterGroup
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) UpdateRouterGroup(arg1 models.RouterGroup) error {
-	fake.updateRouterGroupMutex.Lock()
-	ret, specificReturn := fake.updateRouterGroupReturnsOnCall[len(fake.updateRouterGroupArgsForCall)]
-	fake.updateRouterGroupArgsForCall = append(fake.updateRouterGroupArgsForCall, struct {
-		arg1 models.RouterGroup
-	}{arg1})
-	fake.recordInvocation("UpdateRouterGroup", []interface{}{arg1})
-	fake.updateRouterGroupMutex.Unlock()
-	if fake.UpdateRouterGroupStub != nil {
-		return fake.UpdateRouterGroupStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.updateRouterGroupReturns.result1
-}
-
-func (fake *FakeClient) UpdateRouterGroupCallCount() int {
-	fake.updateRouterGroupMutex.RLock()
-	defer fake.updateRouterGroupMutex.RUnlock()
-	return len(fake.updateRouterGroupArgsForCall)
-}
-
-func (fake *FakeClient) UpdateRouterGroupArgsForCall(i int) models.RouterGroup {
-	fake.updateRouterGroupMutex.RLock()
-	defer fake.updateRouterGroupMutex.RUnlock()
-	return fake.updateRouterGroupArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) UpdateRouterGroupReturns(result1 error) {
-	fake.UpdateRouterGroupStub = nil
-	fake.updateRouterGroupReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) UpdateRouterGroupReturnsOnCall(i int, result1 error) {
-	fake.UpdateRouterGroupStub = nil
-	if fake.updateRouterGroupReturnsOnCall == nil {
-		fake.updateRouterGroupReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.updateRouterGroupReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) CreateRouterGroup(arg1 models.RouterGroup) error {
-	fake.createRouterGroupMutex.Lock()
-	ret, specificReturn := fake.createRouterGroupReturnsOnCall[len(fake.createRouterGroupArgsForCall)]
-	fake.createRouterGroupArgsForCall = append(fake.createRouterGroupArgsForCall, struct {
-		arg1 models.RouterGroup
-	}{arg1})
-	fake.recordInvocation("CreateRouterGroup", []interface{}{arg1})
-	fake.createRouterGroupMutex.Unlock()
-	if fake.CreateRouterGroupStub != nil {
-		return fake.CreateRouterGroupStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.createRouterGroupReturns.result1
-}
-
-func (fake *FakeClient) CreateRouterGroupCallCount() int {
-	fake.createRouterGroupMutex.RLock()
-	defer fake.createRouterGroupMutex.RUnlock()
-	return len(fake.createRouterGroupArgsForCall)
-}
-
-func (fake *FakeClient) CreateRouterGroupArgsForCall(i int) models.RouterGroup {
-	fake.createRouterGroupMutex.RLock()
-	defer fake.createRouterGroupMutex.RUnlock()
-	return fake.createRouterGroupArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) CreateRouterGroupReturns(result1 error) {
-	fake.CreateRouterGroupStub = nil
-	fake.createRouterGroupReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) CreateRouterGroupReturnsOnCall(i int, result1 error) {
-	fake.CreateRouterGroupStub = nil
-	if fake.createRouterGroupReturnsOnCall == nil {
-		fake.createRouterGroupReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.createRouterGroupReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) UpsertTcpRouteMappings(arg1 []models.TcpRouteMapping) error {
-	var arg1Copy []models.TcpRouteMapping
-	if arg1 != nil {
-		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
-		copy(arg1Copy, arg1)
-	}
-	fake.upsertTcpRouteMappingsMutex.Lock()
-	ret, specificReturn := fake.upsertTcpRouteMappingsReturnsOnCall[len(fake.upsertTcpRouteMappingsArgsForCall)]
-	fake.upsertTcpRouteMappingsArgsForCall = append(fake.upsertTcpRouteMappingsArgsForCall, struct {
-		arg1 []models.TcpRouteMapping
-	}{arg1Copy})
-	fake.recordInvocation("UpsertTcpRouteMappings", []interface{}{arg1Copy})
-	fake.upsertTcpRouteMappingsMutex.Unlock()
-	if fake.UpsertTcpRouteMappingsStub != nil {
-		return fake.UpsertTcpRouteMappingsStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.upsertTcpRouteMappingsReturns.result1
-}
-
-func (fake *FakeClient) UpsertTcpRouteMappingsCallCount() int {
-	fake.upsertTcpRouteMappingsMutex.RLock()
-	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
-	return len(fake.upsertTcpRouteMappingsArgsForCall)
-}
-
-func (fake *FakeClient) UpsertTcpRouteMappingsArgsForCall(i int) []models.TcpRouteMapping {
-	fake.upsertTcpRouteMappingsMutex.RLock()
-	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
-	return fake.upsertTcpRouteMappingsArgsForCall[i].arg1
-}
-
-func (fake *FakeClient) UpsertTcpRouteMappingsReturns(result1 error) {
-	fake.UpsertTcpRouteMappingsStub = nil
-	fake.upsertTcpRouteMappingsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) UpsertTcpRouteMappingsReturnsOnCall(i int, result1 error) {
-	fake.UpsertTcpRouteMappingsStub = nil
-	if fake.upsertTcpRouteMappingsReturnsOnCall == nil {
-		fake.upsertTcpRouteMappingsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.upsertTcpRouteMappingsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -626,7 +411,8 @@ func (fake *FakeClient) DeleteTcpRouteMappings(arg1 []models.TcpRouteMapping) er
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.deleteTcpRouteMappingsReturns.result1
+	fakeReturns := fake.deleteTcpRouteMappingsReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) DeleteTcpRouteMappingsCallCount() int {
@@ -635,13 +421,22 @@ func (fake *FakeClient) DeleteTcpRouteMappingsCallCount() int {
 	return len(fake.deleteTcpRouteMappingsArgsForCall)
 }
 
+func (fake *FakeClient) DeleteTcpRouteMappingsCalls(stub func([]models.TcpRouteMapping) error) {
+	fake.deleteTcpRouteMappingsMutex.Lock()
+	defer fake.deleteTcpRouteMappingsMutex.Unlock()
+	fake.DeleteTcpRouteMappingsStub = stub
+}
+
 func (fake *FakeClient) DeleteTcpRouteMappingsArgsForCall(i int) []models.TcpRouteMapping {
 	fake.deleteTcpRouteMappingsMutex.RLock()
 	defer fake.deleteTcpRouteMappingsMutex.RUnlock()
-	return fake.deleteTcpRouteMappingsArgsForCall[i].arg1
+	argsForCall := fake.deleteTcpRouteMappingsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) DeleteTcpRouteMappingsReturns(result1 error) {
+	fake.deleteTcpRouteMappingsMutex.Lock()
+	defer fake.deleteTcpRouteMappingsMutex.Unlock()
 	fake.DeleteTcpRouteMappingsStub = nil
 	fake.deleteTcpRouteMappingsReturns = struct {
 		result1 error
@@ -649,6 +444,8 @@ func (fake *FakeClient) DeleteTcpRouteMappingsReturns(result1 error) {
 }
 
 func (fake *FakeClient) DeleteTcpRouteMappingsReturnsOnCall(i int, result1 error) {
+	fake.deleteTcpRouteMappingsMutex.Lock()
+	defer fake.deleteTcpRouteMappingsMutex.Unlock()
 	fake.DeleteTcpRouteMappingsStub = nil
 	if fake.deleteTcpRouteMappingsReturnsOnCall == nil {
 		fake.deleteTcpRouteMappingsReturnsOnCall = make(map[int]struct {
@@ -658,49 +455,6 @@ func (fake *FakeClient) DeleteTcpRouteMappingsReturnsOnCall(i int, result1 error
 	fake.deleteTcpRouteMappingsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
-}
-
-func (fake *FakeClient) TcpRouteMappings() ([]models.TcpRouteMapping, error) {
-	fake.tcpRouteMappingsMutex.Lock()
-	ret, specificReturn := fake.tcpRouteMappingsReturnsOnCall[len(fake.tcpRouteMappingsArgsForCall)]
-	fake.tcpRouteMappingsArgsForCall = append(fake.tcpRouteMappingsArgsForCall, struct{}{})
-	fake.recordInvocation("TcpRouteMappings", []interface{}{})
-	fake.tcpRouteMappingsMutex.Unlock()
-	if fake.TcpRouteMappingsStub != nil {
-		return fake.TcpRouteMappingsStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.tcpRouteMappingsReturns.result1, fake.tcpRouteMappingsReturns.result2
-}
-
-func (fake *FakeClient) TcpRouteMappingsCallCount() int {
-	fake.tcpRouteMappingsMutex.RLock()
-	defer fake.tcpRouteMappingsMutex.RUnlock()
-	return len(fake.tcpRouteMappingsArgsForCall)
-}
-
-func (fake *FakeClient) TcpRouteMappingsReturns(result1 []models.TcpRouteMapping, result2 error) {
-	fake.TcpRouteMappingsStub = nil
-	fake.tcpRouteMappingsReturns = struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) TcpRouteMappingsReturnsOnCall(i int, result1 []models.TcpRouteMapping, result2 error) {
-	fake.TcpRouteMappingsStub = nil
-	if fake.tcpRouteMappingsReturnsOnCall == nil {
-		fake.tcpRouteMappingsReturnsOnCall = make(map[int]struct {
-			result1 []models.TcpRouteMapping
-			result2 error
-		})
-	}
-	fake.tcpRouteMappingsReturnsOnCall[i] = struct {
-		result1 []models.TcpRouteMapping
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) FilteredTcpRouteMappings(arg1 []string) ([]models.TcpRouteMapping, error) {
@@ -722,7 +476,8 @@ func (fake *FakeClient) FilteredTcpRouteMappings(arg1 []string) ([]models.TcpRou
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.filteredTcpRouteMappingsReturns.result1, fake.filteredTcpRouteMappingsReturns.result2
+	fakeReturns := fake.filteredTcpRouteMappingsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) FilteredTcpRouteMappingsCallCount() int {
@@ -731,13 +486,22 @@ func (fake *FakeClient) FilteredTcpRouteMappingsCallCount() int {
 	return len(fake.filteredTcpRouteMappingsArgsForCall)
 }
 
+func (fake *FakeClient) FilteredTcpRouteMappingsCalls(stub func([]string) ([]models.TcpRouteMapping, error)) {
+	fake.filteredTcpRouteMappingsMutex.Lock()
+	defer fake.filteredTcpRouteMappingsMutex.Unlock()
+	fake.FilteredTcpRouteMappingsStub = stub
+}
+
 func (fake *FakeClient) FilteredTcpRouteMappingsArgsForCall(i int) []string {
 	fake.filteredTcpRouteMappingsMutex.RLock()
 	defer fake.filteredTcpRouteMappingsMutex.RUnlock()
-	return fake.filteredTcpRouteMappingsArgsForCall[i].arg1
+	argsForCall := fake.filteredTcpRouteMappingsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) FilteredTcpRouteMappingsReturns(result1 []models.TcpRouteMapping, result2 error) {
+	fake.filteredTcpRouteMappingsMutex.Lock()
+	defer fake.filteredTcpRouteMappingsMutex.Unlock()
 	fake.FilteredTcpRouteMappingsStub = nil
 	fake.filteredTcpRouteMappingsReturns = struct {
 		result1 []models.TcpRouteMapping
@@ -746,6 +510,8 @@ func (fake *FakeClient) FilteredTcpRouteMappingsReturns(result1 []models.TcpRout
 }
 
 func (fake *FakeClient) FilteredTcpRouteMappingsReturnsOnCall(i int, result1 []models.TcpRouteMapping, result2 error) {
+	fake.filteredTcpRouteMappingsMutex.Lock()
+	defer fake.filteredTcpRouteMappingsMutex.Unlock()
 	fake.FilteredTcpRouteMappingsStub = nil
 	if fake.filteredTcpRouteMappingsReturnsOnCall == nil {
 		fake.filteredTcpRouteMappingsReturnsOnCall = make(map[int]struct {
@@ -759,10 +525,215 @@ func (fake *FakeClient) FilteredTcpRouteMappingsReturnsOnCall(i int, result1 []m
 	}{result1, result2}
 }
 
+func (fake *FakeClient) RouterGroupWithName(arg1 string) (models.RouterGroup, error) {
+	fake.routerGroupWithNameMutex.Lock()
+	ret, specificReturn := fake.routerGroupWithNameReturnsOnCall[len(fake.routerGroupWithNameArgsForCall)]
+	fake.routerGroupWithNameArgsForCall = append(fake.routerGroupWithNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("RouterGroupWithName", []interface{}{arg1})
+	fake.routerGroupWithNameMutex.Unlock()
+	if fake.RouterGroupWithNameStub != nil {
+		return fake.RouterGroupWithNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.routerGroupWithNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) RouterGroupWithNameCallCount() int {
+	fake.routerGroupWithNameMutex.RLock()
+	defer fake.routerGroupWithNameMutex.RUnlock()
+	return len(fake.routerGroupWithNameArgsForCall)
+}
+
+func (fake *FakeClient) RouterGroupWithNameCalls(stub func(string) (models.RouterGroup, error)) {
+	fake.routerGroupWithNameMutex.Lock()
+	defer fake.routerGroupWithNameMutex.Unlock()
+	fake.RouterGroupWithNameStub = stub
+}
+
+func (fake *FakeClient) RouterGroupWithNameArgsForCall(i int) string {
+	fake.routerGroupWithNameMutex.RLock()
+	defer fake.routerGroupWithNameMutex.RUnlock()
+	argsForCall := fake.routerGroupWithNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) RouterGroupWithNameReturns(result1 models.RouterGroup, result2 error) {
+	fake.routerGroupWithNameMutex.Lock()
+	defer fake.routerGroupWithNameMutex.Unlock()
+	fake.RouterGroupWithNameStub = nil
+	fake.routerGroupWithNameReturns = struct {
+		result1 models.RouterGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RouterGroupWithNameReturnsOnCall(i int, result1 models.RouterGroup, result2 error) {
+	fake.routerGroupWithNameMutex.Lock()
+	defer fake.routerGroupWithNameMutex.Unlock()
+	fake.RouterGroupWithNameStub = nil
+	if fake.routerGroupWithNameReturnsOnCall == nil {
+		fake.routerGroupWithNameReturnsOnCall = make(map[int]struct {
+			result1 models.RouterGroup
+			result2 error
+		})
+	}
+	fake.routerGroupWithNameReturnsOnCall[i] = struct {
+		result1 models.RouterGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RouterGroups() ([]models.RouterGroup, error) {
+	fake.routerGroupsMutex.Lock()
+	ret, specificReturn := fake.routerGroupsReturnsOnCall[len(fake.routerGroupsArgsForCall)]
+	fake.routerGroupsArgsForCall = append(fake.routerGroupsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("RouterGroups", []interface{}{})
+	fake.routerGroupsMutex.Unlock()
+	if fake.RouterGroupsStub != nil {
+		return fake.RouterGroupsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.routerGroupsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) RouterGroupsCallCount() int {
+	fake.routerGroupsMutex.RLock()
+	defer fake.routerGroupsMutex.RUnlock()
+	return len(fake.routerGroupsArgsForCall)
+}
+
+func (fake *FakeClient) RouterGroupsCalls(stub func() ([]models.RouterGroup, error)) {
+	fake.routerGroupsMutex.Lock()
+	defer fake.routerGroupsMutex.Unlock()
+	fake.RouterGroupsStub = stub
+}
+
+func (fake *FakeClient) RouterGroupsReturns(result1 []models.RouterGroup, result2 error) {
+	fake.routerGroupsMutex.Lock()
+	defer fake.routerGroupsMutex.Unlock()
+	fake.RouterGroupsStub = nil
+	fake.routerGroupsReturns = struct {
+		result1 []models.RouterGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RouterGroupsReturnsOnCall(i int, result1 []models.RouterGroup, result2 error) {
+	fake.routerGroupsMutex.Lock()
+	defer fake.routerGroupsMutex.Unlock()
+	fake.RouterGroupsStub = nil
+	if fake.routerGroupsReturnsOnCall == nil {
+		fake.routerGroupsReturnsOnCall = make(map[int]struct {
+			result1 []models.RouterGroup
+			result2 error
+		})
+	}
+	fake.routerGroupsReturnsOnCall[i] = struct {
+		result1 []models.RouterGroup
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) Routes() ([]models.Route, error) {
+	fake.routesMutex.Lock()
+	ret, specificReturn := fake.routesReturnsOnCall[len(fake.routesArgsForCall)]
+	fake.routesArgsForCall = append(fake.routesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Routes", []interface{}{})
+	fake.routesMutex.Unlock()
+	if fake.RoutesStub != nil {
+		return fake.RoutesStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.routesReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) RoutesCallCount() int {
+	fake.routesMutex.RLock()
+	defer fake.routesMutex.RUnlock()
+	return len(fake.routesArgsForCall)
+}
+
+func (fake *FakeClient) RoutesCalls(stub func() ([]models.Route, error)) {
+	fake.routesMutex.Lock()
+	defer fake.routesMutex.Unlock()
+	fake.RoutesStub = stub
+}
+
+func (fake *FakeClient) RoutesReturns(result1 []models.Route, result2 error) {
+	fake.routesMutex.Lock()
+	defer fake.routesMutex.Unlock()
+	fake.RoutesStub = nil
+	fake.routesReturns = struct {
+		result1 []models.Route
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) RoutesReturnsOnCall(i int, result1 []models.Route, result2 error) {
+	fake.routesMutex.Lock()
+	defer fake.routesMutex.Unlock()
+	fake.RoutesStub = nil
+	if fake.routesReturnsOnCall == nil {
+		fake.routesReturnsOnCall = make(map[int]struct {
+			result1 []models.Route
+			result2 error
+		})
+	}
+	fake.routesReturnsOnCall[i] = struct {
+		result1 []models.Route
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) SetToken(arg1 string) {
+	fake.setTokenMutex.Lock()
+	fake.setTokenArgsForCall = append(fake.setTokenArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("SetToken", []interface{}{arg1})
+	fake.setTokenMutex.Unlock()
+	if fake.SetTokenStub != nil {
+		fake.SetTokenStub(arg1)
+	}
+}
+
+func (fake *FakeClient) SetTokenCallCount() int {
+	fake.setTokenMutex.RLock()
+	defer fake.setTokenMutex.RUnlock()
+	return len(fake.setTokenArgsForCall)
+}
+
+func (fake *FakeClient) SetTokenCalls(stub func(string)) {
+	fake.setTokenMutex.Lock()
+	defer fake.setTokenMutex.Unlock()
+	fake.SetTokenStub = stub
+}
+
+func (fake *FakeClient) SetTokenArgsForCall(i int) string {
+	fake.setTokenMutex.RLock()
+	defer fake.setTokenMutex.RUnlock()
+	argsForCall := fake.setTokenArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeClient) SubscribeToEvents() (routing_api.EventSource, error) {
 	fake.subscribeToEventsMutex.Lock()
 	ret, specificReturn := fake.subscribeToEventsReturnsOnCall[len(fake.subscribeToEventsArgsForCall)]
-	fake.subscribeToEventsArgsForCall = append(fake.subscribeToEventsArgsForCall, struct{}{})
+	fake.subscribeToEventsArgsForCall = append(fake.subscribeToEventsArgsForCall, struct {
+	}{})
 	fake.recordInvocation("SubscribeToEvents", []interface{}{})
 	fake.subscribeToEventsMutex.Unlock()
 	if fake.SubscribeToEventsStub != nil {
@@ -771,7 +742,8 @@ func (fake *FakeClient) SubscribeToEvents() (routing_api.EventSource, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.subscribeToEventsReturns.result1, fake.subscribeToEventsReturns.result2
+	fakeReturns := fake.subscribeToEventsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) SubscribeToEventsCallCount() int {
@@ -780,7 +752,15 @@ func (fake *FakeClient) SubscribeToEventsCallCount() int {
 	return len(fake.subscribeToEventsArgsForCall)
 }
 
+func (fake *FakeClient) SubscribeToEventsCalls(stub func() (routing_api.EventSource, error)) {
+	fake.subscribeToEventsMutex.Lock()
+	defer fake.subscribeToEventsMutex.Unlock()
+	fake.SubscribeToEventsStub = stub
+}
+
 func (fake *FakeClient) SubscribeToEventsReturns(result1 routing_api.EventSource, result2 error) {
+	fake.subscribeToEventsMutex.Lock()
+	defer fake.subscribeToEventsMutex.Unlock()
 	fake.SubscribeToEventsStub = nil
 	fake.subscribeToEventsReturns = struct {
 		result1 routing_api.EventSource
@@ -789,6 +769,8 @@ func (fake *FakeClient) SubscribeToEventsReturns(result1 routing_api.EventSource
 }
 
 func (fake *FakeClient) SubscribeToEventsReturnsOnCall(i int, result1 routing_api.EventSource, result2 error) {
+	fake.subscribeToEventsMutex.Lock()
+	defer fake.subscribeToEventsMutex.Unlock()
 	fake.SubscribeToEventsStub = nil
 	if fake.subscribeToEventsReturnsOnCall == nil {
 		fake.subscribeToEventsReturnsOnCall = make(map[int]struct {
@@ -802,21 +784,22 @@ func (fake *FakeClient) SubscribeToEventsReturnsOnCall(i int, result1 routing_ap
 	}{result1, result2}
 }
 
-func (fake *FakeClient) SubscribeToEventsWithMaxRetries(retries uint16) (routing_api.EventSource, error) {
+func (fake *FakeClient) SubscribeToEventsWithMaxRetries(arg1 uint16) (routing_api.EventSource, error) {
 	fake.subscribeToEventsWithMaxRetriesMutex.Lock()
 	ret, specificReturn := fake.subscribeToEventsWithMaxRetriesReturnsOnCall[len(fake.subscribeToEventsWithMaxRetriesArgsForCall)]
 	fake.subscribeToEventsWithMaxRetriesArgsForCall = append(fake.subscribeToEventsWithMaxRetriesArgsForCall, struct {
-		retries uint16
-	}{retries})
-	fake.recordInvocation("SubscribeToEventsWithMaxRetries", []interface{}{retries})
+		arg1 uint16
+	}{arg1})
+	fake.recordInvocation("SubscribeToEventsWithMaxRetries", []interface{}{arg1})
 	fake.subscribeToEventsWithMaxRetriesMutex.Unlock()
 	if fake.SubscribeToEventsWithMaxRetriesStub != nil {
-		return fake.SubscribeToEventsWithMaxRetriesStub(retries)
+		return fake.SubscribeToEventsWithMaxRetriesStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.subscribeToEventsWithMaxRetriesReturns.result1, fake.subscribeToEventsWithMaxRetriesReturns.result2
+	fakeReturns := fake.subscribeToEventsWithMaxRetriesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) SubscribeToEventsWithMaxRetriesCallCount() int {
@@ -825,13 +808,22 @@ func (fake *FakeClient) SubscribeToEventsWithMaxRetriesCallCount() int {
 	return len(fake.subscribeToEventsWithMaxRetriesArgsForCall)
 }
 
+func (fake *FakeClient) SubscribeToEventsWithMaxRetriesCalls(stub func(uint16) (routing_api.EventSource, error)) {
+	fake.subscribeToEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToEventsWithMaxRetriesMutex.Unlock()
+	fake.SubscribeToEventsWithMaxRetriesStub = stub
+}
+
 func (fake *FakeClient) SubscribeToEventsWithMaxRetriesArgsForCall(i int) uint16 {
 	fake.subscribeToEventsWithMaxRetriesMutex.RLock()
 	defer fake.subscribeToEventsWithMaxRetriesMutex.RUnlock()
-	return fake.subscribeToEventsWithMaxRetriesArgsForCall[i].retries
+	argsForCall := fake.subscribeToEventsWithMaxRetriesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) SubscribeToEventsWithMaxRetriesReturns(result1 routing_api.EventSource, result2 error) {
+	fake.subscribeToEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToEventsWithMaxRetriesMutex.Unlock()
 	fake.SubscribeToEventsWithMaxRetriesStub = nil
 	fake.subscribeToEventsWithMaxRetriesReturns = struct {
 		result1 routing_api.EventSource
@@ -840,6 +832,8 @@ func (fake *FakeClient) SubscribeToEventsWithMaxRetriesReturns(result1 routing_a
 }
 
 func (fake *FakeClient) SubscribeToEventsWithMaxRetriesReturnsOnCall(i int, result1 routing_api.EventSource, result2 error) {
+	fake.subscribeToEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToEventsWithMaxRetriesMutex.Unlock()
 	fake.SubscribeToEventsWithMaxRetriesStub = nil
 	if fake.subscribeToEventsWithMaxRetriesReturnsOnCall == nil {
 		fake.subscribeToEventsWithMaxRetriesReturnsOnCall = make(map[int]struct {
@@ -856,7 +850,8 @@ func (fake *FakeClient) SubscribeToEventsWithMaxRetriesReturnsOnCall(i int, resu
 func (fake *FakeClient) SubscribeToTcpEvents() (routing_api.TcpEventSource, error) {
 	fake.subscribeToTcpEventsMutex.Lock()
 	ret, specificReturn := fake.subscribeToTcpEventsReturnsOnCall[len(fake.subscribeToTcpEventsArgsForCall)]
-	fake.subscribeToTcpEventsArgsForCall = append(fake.subscribeToTcpEventsArgsForCall, struct{}{})
+	fake.subscribeToTcpEventsArgsForCall = append(fake.subscribeToTcpEventsArgsForCall, struct {
+	}{})
 	fake.recordInvocation("SubscribeToTcpEvents", []interface{}{})
 	fake.subscribeToTcpEventsMutex.Unlock()
 	if fake.SubscribeToTcpEventsStub != nil {
@@ -865,7 +860,8 @@ func (fake *FakeClient) SubscribeToTcpEvents() (routing_api.TcpEventSource, erro
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.subscribeToTcpEventsReturns.result1, fake.subscribeToTcpEventsReturns.result2
+	fakeReturns := fake.subscribeToTcpEventsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) SubscribeToTcpEventsCallCount() int {
@@ -874,7 +870,15 @@ func (fake *FakeClient) SubscribeToTcpEventsCallCount() int {
 	return len(fake.subscribeToTcpEventsArgsForCall)
 }
 
+func (fake *FakeClient) SubscribeToTcpEventsCalls(stub func() (routing_api.TcpEventSource, error)) {
+	fake.subscribeToTcpEventsMutex.Lock()
+	defer fake.subscribeToTcpEventsMutex.Unlock()
+	fake.SubscribeToTcpEventsStub = stub
+}
+
 func (fake *FakeClient) SubscribeToTcpEventsReturns(result1 routing_api.TcpEventSource, result2 error) {
+	fake.subscribeToTcpEventsMutex.Lock()
+	defer fake.subscribeToTcpEventsMutex.Unlock()
 	fake.SubscribeToTcpEventsStub = nil
 	fake.subscribeToTcpEventsReturns = struct {
 		result1 routing_api.TcpEventSource
@@ -883,6 +887,8 @@ func (fake *FakeClient) SubscribeToTcpEventsReturns(result1 routing_api.TcpEvent
 }
 
 func (fake *FakeClient) SubscribeToTcpEventsReturnsOnCall(i int, result1 routing_api.TcpEventSource, result2 error) {
+	fake.subscribeToTcpEventsMutex.Lock()
+	defer fake.subscribeToTcpEventsMutex.Unlock()
 	fake.SubscribeToTcpEventsStub = nil
 	if fake.subscribeToTcpEventsReturnsOnCall == nil {
 		fake.subscribeToTcpEventsReturnsOnCall = make(map[int]struct {
@@ -896,21 +902,22 @@ func (fake *FakeClient) SubscribeToTcpEventsReturnsOnCall(i int, result1 routing
 	}{result1, result2}
 }
 
-func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetries(retries uint16) (routing_api.TcpEventSource, error) {
+func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetries(arg1 uint16) (routing_api.TcpEventSource, error) {
 	fake.subscribeToTcpEventsWithMaxRetriesMutex.Lock()
 	ret, specificReturn := fake.subscribeToTcpEventsWithMaxRetriesReturnsOnCall[len(fake.subscribeToTcpEventsWithMaxRetriesArgsForCall)]
 	fake.subscribeToTcpEventsWithMaxRetriesArgsForCall = append(fake.subscribeToTcpEventsWithMaxRetriesArgsForCall, struct {
-		retries uint16
-	}{retries})
-	fake.recordInvocation("SubscribeToTcpEventsWithMaxRetries", []interface{}{retries})
+		arg1 uint16
+	}{arg1})
+	fake.recordInvocation("SubscribeToTcpEventsWithMaxRetries", []interface{}{arg1})
 	fake.subscribeToTcpEventsWithMaxRetriesMutex.Unlock()
 	if fake.SubscribeToTcpEventsWithMaxRetriesStub != nil {
-		return fake.SubscribeToTcpEventsWithMaxRetriesStub(retries)
+		return fake.SubscribeToTcpEventsWithMaxRetriesStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.subscribeToTcpEventsWithMaxRetriesReturns.result1, fake.subscribeToTcpEventsWithMaxRetriesReturns.result2
+	fakeReturns := fake.subscribeToTcpEventsWithMaxRetriesReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesCallCount() int {
@@ -919,13 +926,22 @@ func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesCallCount() int {
 	return len(fake.subscribeToTcpEventsWithMaxRetriesArgsForCall)
 }
 
+func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesCalls(stub func(uint16) (routing_api.TcpEventSource, error)) {
+	fake.subscribeToTcpEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToTcpEventsWithMaxRetriesMutex.Unlock()
+	fake.SubscribeToTcpEventsWithMaxRetriesStub = stub
+}
+
 func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesArgsForCall(i int) uint16 {
 	fake.subscribeToTcpEventsWithMaxRetriesMutex.RLock()
 	defer fake.subscribeToTcpEventsWithMaxRetriesMutex.RUnlock()
-	return fake.subscribeToTcpEventsWithMaxRetriesArgsForCall[i].retries
+	argsForCall := fake.subscribeToTcpEventsWithMaxRetriesArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesReturns(result1 routing_api.TcpEventSource, result2 error) {
+	fake.subscribeToTcpEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToTcpEventsWithMaxRetriesMutex.Unlock()
 	fake.SubscribeToTcpEventsWithMaxRetriesStub = nil
 	fake.subscribeToTcpEventsWithMaxRetriesReturns = struct {
 		result1 routing_api.TcpEventSource
@@ -934,6 +950,8 @@ func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesReturns(result1 routin
 }
 
 func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesReturnsOnCall(i int, result1 routing_api.TcpEventSource, result2 error) {
+	fake.subscribeToTcpEventsWithMaxRetriesMutex.Lock()
+	defer fake.subscribeToTcpEventsWithMaxRetriesMutex.Unlock()
 	fake.SubscribeToTcpEventsWithMaxRetriesStub = nil
 	if fake.subscribeToTcpEventsWithMaxRetriesReturnsOnCall == nil {
 		fake.subscribeToTcpEventsWithMaxRetriesReturnsOnCall = make(map[int]struct {
@@ -947,33 +965,272 @@ func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetriesReturnsOnCall(i int, r
 	}{result1, result2}
 }
 
+func (fake *FakeClient) TcpRouteMappings() ([]models.TcpRouteMapping, error) {
+	fake.tcpRouteMappingsMutex.Lock()
+	ret, specificReturn := fake.tcpRouteMappingsReturnsOnCall[len(fake.tcpRouteMappingsArgsForCall)]
+	fake.tcpRouteMappingsArgsForCall = append(fake.tcpRouteMappingsArgsForCall, struct {
+	}{})
+	fake.recordInvocation("TcpRouteMappings", []interface{}{})
+	fake.tcpRouteMappingsMutex.Unlock()
+	if fake.TcpRouteMappingsStub != nil {
+		return fake.TcpRouteMappingsStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.tcpRouteMappingsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) TcpRouteMappingsCallCount() int {
+	fake.tcpRouteMappingsMutex.RLock()
+	defer fake.tcpRouteMappingsMutex.RUnlock()
+	return len(fake.tcpRouteMappingsArgsForCall)
+}
+
+func (fake *FakeClient) TcpRouteMappingsCalls(stub func() ([]models.TcpRouteMapping, error)) {
+	fake.tcpRouteMappingsMutex.Lock()
+	defer fake.tcpRouteMappingsMutex.Unlock()
+	fake.TcpRouteMappingsStub = stub
+}
+
+func (fake *FakeClient) TcpRouteMappingsReturns(result1 []models.TcpRouteMapping, result2 error) {
+	fake.tcpRouteMappingsMutex.Lock()
+	defer fake.tcpRouteMappingsMutex.Unlock()
+	fake.TcpRouteMappingsStub = nil
+	fake.tcpRouteMappingsReturns = struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) TcpRouteMappingsReturnsOnCall(i int, result1 []models.TcpRouteMapping, result2 error) {
+	fake.tcpRouteMappingsMutex.Lock()
+	defer fake.tcpRouteMappingsMutex.Unlock()
+	fake.TcpRouteMappingsStub = nil
+	if fake.tcpRouteMappingsReturnsOnCall == nil {
+		fake.tcpRouteMappingsReturnsOnCall = make(map[int]struct {
+			result1 []models.TcpRouteMapping
+			result2 error
+		})
+	}
+	fake.tcpRouteMappingsReturnsOnCall[i] = struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) UpdateRouterGroup(arg1 models.RouterGroup) error {
+	fake.updateRouterGroupMutex.Lock()
+	ret, specificReturn := fake.updateRouterGroupReturnsOnCall[len(fake.updateRouterGroupArgsForCall)]
+	fake.updateRouterGroupArgsForCall = append(fake.updateRouterGroupArgsForCall, struct {
+		arg1 models.RouterGroup
+	}{arg1})
+	fake.recordInvocation("UpdateRouterGroup", []interface{}{arg1})
+	fake.updateRouterGroupMutex.Unlock()
+	if fake.UpdateRouterGroupStub != nil {
+		return fake.UpdateRouterGroupStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.updateRouterGroupReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) UpdateRouterGroupCallCount() int {
+	fake.updateRouterGroupMutex.RLock()
+	defer fake.updateRouterGroupMutex.RUnlock()
+	return len(fake.updateRouterGroupArgsForCall)
+}
+
+func (fake *FakeClient) UpdateRouterGroupCalls(stub func(models.RouterGroup) error) {
+	fake.updateRouterGroupMutex.Lock()
+	defer fake.updateRouterGroupMutex.Unlock()
+	fake.UpdateRouterGroupStub = stub
+}
+
+func (fake *FakeClient) UpdateRouterGroupArgsForCall(i int) models.RouterGroup {
+	fake.updateRouterGroupMutex.RLock()
+	defer fake.updateRouterGroupMutex.RUnlock()
+	argsForCall := fake.updateRouterGroupArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) UpdateRouterGroupReturns(result1 error) {
+	fake.updateRouterGroupMutex.Lock()
+	defer fake.updateRouterGroupMutex.Unlock()
+	fake.UpdateRouterGroupStub = nil
+	fake.updateRouterGroupReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UpdateRouterGroupReturnsOnCall(i int, result1 error) {
+	fake.updateRouterGroupMutex.Lock()
+	defer fake.updateRouterGroupMutex.Unlock()
+	fake.UpdateRouterGroupStub = nil
+	if fake.updateRouterGroupReturnsOnCall == nil {
+		fake.updateRouterGroupReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateRouterGroupReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UpsertRoutes(arg1 []models.Route) error {
+	var arg1Copy []models.Route
+	if arg1 != nil {
+		arg1Copy = make([]models.Route, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.upsertRoutesMutex.Lock()
+	ret, specificReturn := fake.upsertRoutesReturnsOnCall[len(fake.upsertRoutesArgsForCall)]
+	fake.upsertRoutesArgsForCall = append(fake.upsertRoutesArgsForCall, struct {
+		arg1 []models.Route
+	}{arg1Copy})
+	fake.recordInvocation("UpsertRoutes", []interface{}{arg1Copy})
+	fake.upsertRoutesMutex.Unlock()
+	if fake.UpsertRoutesStub != nil {
+		return fake.UpsertRoutesStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.upsertRoutesReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) UpsertRoutesCallCount() int {
+	fake.upsertRoutesMutex.RLock()
+	defer fake.upsertRoutesMutex.RUnlock()
+	return len(fake.upsertRoutesArgsForCall)
+}
+
+func (fake *FakeClient) UpsertRoutesCalls(stub func([]models.Route) error) {
+	fake.upsertRoutesMutex.Lock()
+	defer fake.upsertRoutesMutex.Unlock()
+	fake.UpsertRoutesStub = stub
+}
+
+func (fake *FakeClient) UpsertRoutesArgsForCall(i int) []models.Route {
+	fake.upsertRoutesMutex.RLock()
+	defer fake.upsertRoutesMutex.RUnlock()
+	argsForCall := fake.upsertRoutesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) UpsertRoutesReturns(result1 error) {
+	fake.upsertRoutesMutex.Lock()
+	defer fake.upsertRoutesMutex.Unlock()
+	fake.UpsertRoutesStub = nil
+	fake.upsertRoutesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UpsertRoutesReturnsOnCall(i int, result1 error) {
+	fake.upsertRoutesMutex.Lock()
+	defer fake.upsertRoutesMutex.Unlock()
+	fake.UpsertRoutesStub = nil
+	if fake.upsertRoutesReturnsOnCall == nil {
+		fake.upsertRoutesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.upsertRoutesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappings(arg1 []models.TcpRouteMapping) error {
+	var arg1Copy []models.TcpRouteMapping
+	if arg1 != nil {
+		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.upsertTcpRouteMappingsMutex.Lock()
+	ret, specificReturn := fake.upsertTcpRouteMappingsReturnsOnCall[len(fake.upsertTcpRouteMappingsArgsForCall)]
+	fake.upsertTcpRouteMappingsArgsForCall = append(fake.upsertTcpRouteMappingsArgsForCall, struct {
+		arg1 []models.TcpRouteMapping
+	}{arg1Copy})
+	fake.recordInvocation("UpsertTcpRouteMappings", []interface{}{arg1Copy})
+	fake.upsertTcpRouteMappingsMutex.Unlock()
+	if fake.UpsertTcpRouteMappingsStub != nil {
+		return fake.UpsertTcpRouteMappingsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.upsertTcpRouteMappingsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappingsCallCount() int {
+	fake.upsertTcpRouteMappingsMutex.RLock()
+	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
+	return len(fake.upsertTcpRouteMappingsArgsForCall)
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappingsCalls(stub func([]models.TcpRouteMapping) error) {
+	fake.upsertTcpRouteMappingsMutex.Lock()
+	defer fake.upsertTcpRouteMappingsMutex.Unlock()
+	fake.UpsertTcpRouteMappingsStub = stub
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappingsArgsForCall(i int) []models.TcpRouteMapping {
+	fake.upsertTcpRouteMappingsMutex.RLock()
+	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
+	argsForCall := fake.upsertTcpRouteMappingsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappingsReturns(result1 error) {
+	fake.upsertTcpRouteMappingsMutex.Lock()
+	defer fake.upsertTcpRouteMappingsMutex.Unlock()
+	fake.UpsertTcpRouteMappingsStub = nil
+	fake.upsertTcpRouteMappingsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) UpsertTcpRouteMappingsReturnsOnCall(i int, result1 error) {
+	fake.upsertTcpRouteMappingsMutex.Lock()
+	defer fake.upsertTcpRouteMappingsMutex.Unlock()
+	fake.UpsertTcpRouteMappingsStub = nil
+	if fake.upsertTcpRouteMappingsReturnsOnCall == nil {
+		fake.upsertTcpRouteMappingsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.upsertTcpRouteMappingsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.setTokenMutex.RLock()
-	defer fake.setTokenMutex.RUnlock()
-	fake.upsertRoutesMutex.RLock()
-	defer fake.upsertRoutesMutex.RUnlock()
-	fake.routesMutex.RLock()
-	defer fake.routesMutex.RUnlock()
-	fake.deleteRoutesMutex.RLock()
-	defer fake.deleteRoutesMutex.RUnlock()
-	fake.routerGroupsMutex.RLock()
-	defer fake.routerGroupsMutex.RUnlock()
-	fake.routerGroupWithNameMutex.RLock()
-	defer fake.routerGroupWithNameMutex.RUnlock()
-	fake.updateRouterGroupMutex.RLock()
-	defer fake.updateRouterGroupMutex.RUnlock()
 	fake.createRouterGroupMutex.RLock()
 	defer fake.createRouterGroupMutex.RUnlock()
-	fake.upsertTcpRouteMappingsMutex.RLock()
-	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
+	fake.deleteRouterGroupMutex.RLock()
+	defer fake.deleteRouterGroupMutex.RUnlock()
+	fake.deleteRoutesMutex.RLock()
+	defer fake.deleteRoutesMutex.RUnlock()
 	fake.deleteTcpRouteMappingsMutex.RLock()
 	defer fake.deleteTcpRouteMappingsMutex.RUnlock()
-	fake.tcpRouteMappingsMutex.RLock()
-	defer fake.tcpRouteMappingsMutex.RUnlock()
 	fake.filteredTcpRouteMappingsMutex.RLock()
 	defer fake.filteredTcpRouteMappingsMutex.RUnlock()
+	fake.routerGroupWithNameMutex.RLock()
+	defer fake.routerGroupWithNameMutex.RUnlock()
+	fake.routerGroupsMutex.RLock()
+	defer fake.routerGroupsMutex.RUnlock()
+	fake.routesMutex.RLock()
+	defer fake.routesMutex.RUnlock()
+	fake.setTokenMutex.RLock()
+	defer fake.setTokenMutex.RUnlock()
 	fake.subscribeToEventsMutex.RLock()
 	defer fake.subscribeToEventsMutex.RUnlock()
 	fake.subscribeToEventsWithMaxRetriesMutex.RLock()
@@ -982,6 +1239,14 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.subscribeToTcpEventsMutex.RUnlock()
 	fake.subscribeToTcpEventsWithMaxRetriesMutex.RLock()
 	defer fake.subscribeToTcpEventsWithMaxRetriesMutex.RUnlock()
+	fake.tcpRouteMappingsMutex.RLock()
+	defer fake.tcpRouteMappingsMutex.RUnlock()
+	fake.updateRouterGroupMutex.RLock()
+	defer fake.updateRouterGroupMutex.RUnlock()
+	fake.upsertRoutesMutex.RLock()
+	defer fake.upsertRoutesMutex.RUnlock()
+	fake.upsertTcpRouteMappingsMutex.RLock()
+	defer fake.upsertTcpRouteMappingsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/fake_routing_api/fake_event_source.go
+++ b/fake_routing_api/fake_event_source.go
@@ -8,10 +8,21 @@ import (
 )
 
 type FakeEventSource struct {
+	CloseStub        func() error
+	closeMutex       sync.RWMutex
+	closeArgsForCall []struct {
+	}
+	closeReturns struct {
+		result1 error
+	}
+	closeReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NextStub        func() (routing_api.Event, error)
 	nextMutex       sync.RWMutex
-	nextArgsForCall []struct{}
-	nextReturns     struct {
+	nextArgsForCall []struct {
+	}
+	nextReturns struct {
 		result1 routing_api.Event
 		result2 error
 	}
@@ -19,23 +30,67 @@ type FakeEventSource struct {
 		result1 routing_api.Event
 		result2 error
 	}
-	CloseStub        func() error
-	closeMutex       sync.RWMutex
-	closeArgsForCall []struct{}
-	closeReturns     struct {
-		result1 error
-	}
-	closeReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeEventSource) Close() error {
+	fake.closeMutex.Lock()
+	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
+	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Close", []interface{}{})
+	fake.closeMutex.Unlock()
+	if fake.CloseStub != nil {
+		return fake.CloseStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.closeReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeEventSource) CloseCallCount() int {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	return len(fake.closeArgsForCall)
+}
+
+func (fake *FakeEventSource) CloseCalls(stub func() error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = stub
+}
+
+func (fake *FakeEventSource) CloseReturns(result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	fake.closeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeEventSource) CloseReturnsOnCall(i int, result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	if fake.closeReturnsOnCall == nil {
+		fake.closeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.closeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeEventSource) Next() (routing_api.Event, error) {
 	fake.nextMutex.Lock()
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
-	fake.nextArgsForCall = append(fake.nextArgsForCall, struct{}{})
+	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
 	if fake.NextStub != nil {
@@ -44,7 +99,8 @@ func (fake *FakeEventSource) Next() (routing_api.Event, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.nextReturns.result1, fake.nextReturns.result2
+	fakeReturns := fake.nextReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeEventSource) NextCallCount() int {
@@ -53,7 +109,15 @@ func (fake *FakeEventSource) NextCallCount() int {
 	return len(fake.nextArgsForCall)
 }
 
+func (fake *FakeEventSource) NextCalls(stub func() (routing_api.Event, error)) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
+	fake.NextStub = stub
+}
+
 func (fake *FakeEventSource) NextReturns(result1 routing_api.Event, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	fake.nextReturns = struct {
 		result1 routing_api.Event
@@ -62,6 +126,8 @@ func (fake *FakeEventSource) NextReturns(result1 routing_api.Event, result2 erro
 }
 
 func (fake *FakeEventSource) NextReturnsOnCall(i int, result1 routing_api.Event, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	if fake.nextReturnsOnCall == nil {
 		fake.nextReturnsOnCall = make(map[int]struct {
@@ -75,53 +141,13 @@ func (fake *FakeEventSource) NextReturnsOnCall(i int, result1 routing_api.Event,
 	}{result1, result2}
 }
 
-func (fake *FakeEventSource) Close() error {
-	fake.closeMutex.Lock()
-	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
-	fake.closeArgsForCall = append(fake.closeArgsForCall, struct{}{})
-	fake.recordInvocation("Close", []interface{}{})
-	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.closeReturns.result1
-}
-
-func (fake *FakeEventSource) CloseCallCount() int {
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
-	return len(fake.closeArgsForCall)
-}
-
-func (fake *FakeEventSource) CloseReturns(result1 error) {
-	fake.CloseStub = nil
-	fake.closeReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeEventSource) CloseReturnsOnCall(i int, result1 error) {
-	fake.CloseStub = nil
-	if fake.closeReturnsOnCall == nil {
-		fake.closeReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.closeReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeEventSource) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.nextMutex.RLock()
-	defer fake.nextMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
+	fake.nextMutex.RLock()
+	defer fake.nextMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/fake_routing_api/fake_tcp_event_source.go
+++ b/fake_routing_api/fake_tcp_event_source.go
@@ -8,10 +8,21 @@ import (
 )
 
 type FakeTcpEventSource struct {
+	CloseStub        func() error
+	closeMutex       sync.RWMutex
+	closeArgsForCall []struct {
+	}
+	closeReturns struct {
+		result1 error
+	}
+	closeReturnsOnCall map[int]struct {
+		result1 error
+	}
 	NextStub        func() (routing_api.TcpEvent, error)
 	nextMutex       sync.RWMutex
-	nextArgsForCall []struct{}
-	nextReturns     struct {
+	nextArgsForCall []struct {
+	}
+	nextReturns struct {
 		result1 routing_api.TcpEvent
 		result2 error
 	}
@@ -19,23 +30,67 @@ type FakeTcpEventSource struct {
 		result1 routing_api.TcpEvent
 		result2 error
 	}
-	CloseStub        func() error
-	closeMutex       sync.RWMutex
-	closeArgsForCall []struct{}
-	closeReturns     struct {
-		result1 error
-	}
-	closeReturnsOnCall map[int]struct {
-		result1 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeTcpEventSource) Close() error {
+	fake.closeMutex.Lock()
+	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
+	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
+	}{})
+	fake.recordInvocation("Close", []interface{}{})
+	fake.closeMutex.Unlock()
+	if fake.CloseStub != nil {
+		return fake.CloseStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.closeReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeTcpEventSource) CloseCallCount() int {
+	fake.closeMutex.RLock()
+	defer fake.closeMutex.RUnlock()
+	return len(fake.closeArgsForCall)
+}
+
+func (fake *FakeTcpEventSource) CloseCalls(stub func() error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = stub
+}
+
+func (fake *FakeTcpEventSource) CloseReturns(result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	fake.closeReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeTcpEventSource) CloseReturnsOnCall(i int, result1 error) {
+	fake.closeMutex.Lock()
+	defer fake.closeMutex.Unlock()
+	fake.CloseStub = nil
+	if fake.closeReturnsOnCall == nil {
+		fake.closeReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.closeReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeTcpEventSource) Next() (routing_api.TcpEvent, error) {
 	fake.nextMutex.Lock()
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
-	fake.nextArgsForCall = append(fake.nextArgsForCall, struct{}{})
+	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
 	if fake.NextStub != nil {
@@ -44,7 +99,8 @@ func (fake *FakeTcpEventSource) Next() (routing_api.TcpEvent, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.nextReturns.result1, fake.nextReturns.result2
+	fakeReturns := fake.nextReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeTcpEventSource) NextCallCount() int {
@@ -53,7 +109,15 @@ func (fake *FakeTcpEventSource) NextCallCount() int {
 	return len(fake.nextArgsForCall)
 }
 
+func (fake *FakeTcpEventSource) NextCalls(stub func() (routing_api.TcpEvent, error)) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
+	fake.NextStub = stub
+}
+
 func (fake *FakeTcpEventSource) NextReturns(result1 routing_api.TcpEvent, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	fake.nextReturns = struct {
 		result1 routing_api.TcpEvent
@@ -62,6 +126,8 @@ func (fake *FakeTcpEventSource) NextReturns(result1 routing_api.TcpEvent, result
 }
 
 func (fake *FakeTcpEventSource) NextReturnsOnCall(i int, result1 routing_api.TcpEvent, result2 error) {
+	fake.nextMutex.Lock()
+	defer fake.nextMutex.Unlock()
 	fake.NextStub = nil
 	if fake.nextReturnsOnCall == nil {
 		fake.nextReturnsOnCall = make(map[int]struct {
@@ -75,53 +141,13 @@ func (fake *FakeTcpEventSource) NextReturnsOnCall(i int, result1 routing_api.Tcp
 	}{result1, result2}
 }
 
-func (fake *FakeTcpEventSource) Close() error {
-	fake.closeMutex.Lock()
-	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
-	fake.closeArgsForCall = append(fake.closeArgsForCall, struct{}{})
-	fake.recordInvocation("Close", []interface{}{})
-	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.closeReturns.result1
-}
-
-func (fake *FakeTcpEventSource) CloseCallCount() int {
-	fake.closeMutex.RLock()
-	defer fake.closeMutex.RUnlock()
-	return len(fake.closeArgsForCall)
-}
-
-func (fake *FakeTcpEventSource) CloseReturns(result1 error) {
-	fake.CloseStub = nil
-	fake.closeReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeTcpEventSource) CloseReturnsOnCall(i int, result1 error) {
-	fake.CloseStub = nil
-	if fake.closeReturnsOnCall == nil {
-		fake.closeReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.closeReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeTcpEventSource) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.nextMutex.RLock()
-	defer fake.nextMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
+	fake.nextMutex.RLock()
+	defer fake.nextMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/handlers/fakes/fake_validator.go
+++ b/handlers/fakes/fake_validator.go
@@ -10,11 +10,11 @@ import (
 )
 
 type FakeRouteValidator struct {
-	ValidateCreateStub        func(routes []models.Route, maxTTL int) *routing_api.Error
+	ValidateCreateStub        func([]models.Route, int) *routing_api.Error
 	validateCreateMutex       sync.RWMutex
 	validateCreateArgsForCall []struct {
-		routes []models.Route
-		maxTTL int
+		arg1 []models.Route
+		arg2 int
 	}
 	validateCreateReturns struct {
 		result1 *routing_api.Error
@@ -22,23 +22,12 @@ type FakeRouteValidator struct {
 	validateCreateReturnsOnCall map[int]struct {
 		result1 *routing_api.Error
 	}
-	ValidateDeleteStub        func(routes []models.Route) *routing_api.Error
-	validateDeleteMutex       sync.RWMutex
-	validateDeleteArgsForCall []struct {
-		routes []models.Route
-	}
-	validateDeleteReturns struct {
-		result1 *routing_api.Error
-	}
-	validateDeleteReturnsOnCall map[int]struct {
-		result1 *routing_api.Error
-	}
-	ValidateCreateTcpRouteMappingStub        func(tcpRouteMappings []models.TcpRouteMapping, routerGroups models.RouterGroups, maxTTL int) *routing_api.Error
+	ValidateCreateTcpRouteMappingStub        func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error
 	validateCreateTcpRouteMappingMutex       sync.RWMutex
 	validateCreateTcpRouteMappingArgsForCall []struct {
-		tcpRouteMappings []models.TcpRouteMapping
-		routerGroups     models.RouterGroups
-		maxTTL           int
+		arg1 []models.TcpRouteMapping
+		arg2 models.RouterGroups
+		arg3 int
 	}
 	validateCreateTcpRouteMappingReturns struct {
 		result1 *routing_api.Error
@@ -46,10 +35,21 @@ type FakeRouteValidator struct {
 	validateCreateTcpRouteMappingReturnsOnCall map[int]struct {
 		result1 *routing_api.Error
 	}
-	ValidateDeleteTcpRouteMappingStub        func(tcpRouteMappings []models.TcpRouteMapping) *routing_api.Error
+	ValidateDeleteStub        func([]models.Route) *routing_api.Error
+	validateDeleteMutex       sync.RWMutex
+	validateDeleteArgsForCall []struct {
+		arg1 []models.Route
+	}
+	validateDeleteReturns struct {
+		result1 *routing_api.Error
+	}
+	validateDeleteReturnsOnCall map[int]struct {
+		result1 *routing_api.Error
+	}
+	ValidateDeleteTcpRouteMappingStub        func([]models.TcpRouteMapping) *routing_api.Error
 	validateDeleteTcpRouteMappingMutex       sync.RWMutex
 	validateDeleteTcpRouteMappingArgsForCall []struct {
-		tcpRouteMappings []models.TcpRouteMapping
+		arg1 []models.TcpRouteMapping
 	}
 	validateDeleteTcpRouteMappingReturns struct {
 		result1 *routing_api.Error
@@ -61,27 +61,28 @@ type FakeRouteValidator struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeRouteValidator) ValidateCreate(routes []models.Route, maxTTL int) *routing_api.Error {
-	var routesCopy []models.Route
-	if routes != nil {
-		routesCopy = make([]models.Route, len(routes))
-		copy(routesCopy, routes)
+func (fake *FakeRouteValidator) ValidateCreate(arg1 []models.Route, arg2 int) *routing_api.Error {
+	var arg1Copy []models.Route
+	if arg1 != nil {
+		arg1Copy = make([]models.Route, len(arg1))
+		copy(arg1Copy, arg1)
 	}
 	fake.validateCreateMutex.Lock()
 	ret, specificReturn := fake.validateCreateReturnsOnCall[len(fake.validateCreateArgsForCall)]
 	fake.validateCreateArgsForCall = append(fake.validateCreateArgsForCall, struct {
-		routes []models.Route
-		maxTTL int
-	}{routesCopy, maxTTL})
-	fake.recordInvocation("ValidateCreate", []interface{}{routesCopy, maxTTL})
+		arg1 []models.Route
+		arg2 int
+	}{arg1Copy, arg2})
+	fake.recordInvocation("ValidateCreate", []interface{}{arg1Copy, arg2})
 	fake.validateCreateMutex.Unlock()
 	if fake.ValidateCreateStub != nil {
-		return fake.ValidateCreateStub(routes, maxTTL)
+		return fake.ValidateCreateStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.validateCreateReturns.result1
+	fakeReturns := fake.validateCreateReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeRouteValidator) ValidateCreateCallCount() int {
@@ -90,13 +91,22 @@ func (fake *FakeRouteValidator) ValidateCreateCallCount() int {
 	return len(fake.validateCreateArgsForCall)
 }
 
+func (fake *FakeRouteValidator) ValidateCreateCalls(stub func([]models.Route, int) *routing_api.Error) {
+	fake.validateCreateMutex.Lock()
+	defer fake.validateCreateMutex.Unlock()
+	fake.ValidateCreateStub = stub
+}
+
 func (fake *FakeRouteValidator) ValidateCreateArgsForCall(i int) ([]models.Route, int) {
 	fake.validateCreateMutex.RLock()
 	defer fake.validateCreateMutex.RUnlock()
-	return fake.validateCreateArgsForCall[i].routes, fake.validateCreateArgsForCall[i].maxTTL
+	argsForCall := fake.validateCreateArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeRouteValidator) ValidateCreateReturns(result1 *routing_api.Error) {
+	fake.validateCreateMutex.Lock()
+	defer fake.validateCreateMutex.Unlock()
 	fake.ValidateCreateStub = nil
 	fake.validateCreateReturns = struct {
 		result1 *routing_api.Error
@@ -104,6 +114,8 @@ func (fake *FakeRouteValidator) ValidateCreateReturns(result1 *routing_api.Error
 }
 
 func (fake *FakeRouteValidator) ValidateCreateReturnsOnCall(i int, result1 *routing_api.Error) {
+	fake.validateCreateMutex.Lock()
+	defer fake.validateCreateMutex.Unlock()
 	fake.ValidateCreateStub = nil
 	if fake.validateCreateReturnsOnCall == nil {
 		fake.validateCreateReturnsOnCall = make(map[int]struct {
@@ -115,81 +127,29 @@ func (fake *FakeRouteValidator) ValidateCreateReturnsOnCall(i int, result1 *rout
 	}{result1}
 }
 
-func (fake *FakeRouteValidator) ValidateDelete(routes []models.Route) *routing_api.Error {
-	var routesCopy []models.Route
-	if routes != nil {
-		routesCopy = make([]models.Route, len(routes))
-		copy(routesCopy, routes)
-	}
-	fake.validateDeleteMutex.Lock()
-	ret, specificReturn := fake.validateDeleteReturnsOnCall[len(fake.validateDeleteArgsForCall)]
-	fake.validateDeleteArgsForCall = append(fake.validateDeleteArgsForCall, struct {
-		routes []models.Route
-	}{routesCopy})
-	fake.recordInvocation("ValidateDelete", []interface{}{routesCopy})
-	fake.validateDeleteMutex.Unlock()
-	if fake.ValidateDeleteStub != nil {
-		return fake.ValidateDeleteStub(routes)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.validateDeleteReturns.result1
-}
-
-func (fake *FakeRouteValidator) ValidateDeleteCallCount() int {
-	fake.validateDeleteMutex.RLock()
-	defer fake.validateDeleteMutex.RUnlock()
-	return len(fake.validateDeleteArgsForCall)
-}
-
-func (fake *FakeRouteValidator) ValidateDeleteArgsForCall(i int) []models.Route {
-	fake.validateDeleteMutex.RLock()
-	defer fake.validateDeleteMutex.RUnlock()
-	return fake.validateDeleteArgsForCall[i].routes
-}
-
-func (fake *FakeRouteValidator) ValidateDeleteReturns(result1 *routing_api.Error) {
-	fake.ValidateDeleteStub = nil
-	fake.validateDeleteReturns = struct {
-		result1 *routing_api.Error
-	}{result1}
-}
-
-func (fake *FakeRouteValidator) ValidateDeleteReturnsOnCall(i int, result1 *routing_api.Error) {
-	fake.ValidateDeleteStub = nil
-	if fake.validateDeleteReturnsOnCall == nil {
-		fake.validateDeleteReturnsOnCall = make(map[int]struct {
-			result1 *routing_api.Error
-		})
-	}
-	fake.validateDeleteReturnsOnCall[i] = struct {
-		result1 *routing_api.Error
-	}{result1}
-}
-
-func (fake *FakeRouteValidator) ValidateCreateTcpRouteMapping(tcpRouteMappings []models.TcpRouteMapping, routerGroups models.RouterGroups, maxTTL int) *routing_api.Error {
-	var tcpRouteMappingsCopy []models.TcpRouteMapping
-	if tcpRouteMappings != nil {
-		tcpRouteMappingsCopy = make([]models.TcpRouteMapping, len(tcpRouteMappings))
-		copy(tcpRouteMappingsCopy, tcpRouteMappings)
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMapping(arg1 []models.TcpRouteMapping, arg2 models.RouterGroups, arg3 int) *routing_api.Error {
+	var arg1Copy []models.TcpRouteMapping
+	if arg1 != nil {
+		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
+		copy(arg1Copy, arg1)
 	}
 	fake.validateCreateTcpRouteMappingMutex.Lock()
 	ret, specificReturn := fake.validateCreateTcpRouteMappingReturnsOnCall[len(fake.validateCreateTcpRouteMappingArgsForCall)]
 	fake.validateCreateTcpRouteMappingArgsForCall = append(fake.validateCreateTcpRouteMappingArgsForCall, struct {
-		tcpRouteMappings []models.TcpRouteMapping
-		routerGroups     models.RouterGroups
-		maxTTL           int
-	}{tcpRouteMappingsCopy, routerGroups, maxTTL})
-	fake.recordInvocation("ValidateCreateTcpRouteMapping", []interface{}{tcpRouteMappingsCopy, routerGroups, maxTTL})
+		arg1 []models.TcpRouteMapping
+		arg2 models.RouterGroups
+		arg3 int
+	}{arg1Copy, arg2, arg3})
+	fake.recordInvocation("ValidateCreateTcpRouteMapping", []interface{}{arg1Copy, arg2, arg3})
 	fake.validateCreateTcpRouteMappingMutex.Unlock()
 	if fake.ValidateCreateTcpRouteMappingStub != nil {
-		return fake.ValidateCreateTcpRouteMappingStub(tcpRouteMappings, routerGroups, maxTTL)
+		return fake.ValidateCreateTcpRouteMappingStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.validateCreateTcpRouteMappingReturns.result1
+	fakeReturns := fake.validateCreateTcpRouteMappingReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCallCount() int {
@@ -198,13 +158,22 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCallCount() int {
 	return len(fake.validateCreateTcpRouteMappingArgsForCall)
 }
 
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCalls(stub func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingMutex.Unlock()
+	fake.ValidateCreateTcpRouteMappingStub = stub
+}
+
 func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingArgsForCall(i int) ([]models.TcpRouteMapping, models.RouterGroups, int) {
 	fake.validateCreateTcpRouteMappingMutex.RLock()
 	defer fake.validateCreateTcpRouteMappingMutex.RUnlock()
-	return fake.validateCreateTcpRouteMappingArgsForCall[i].tcpRouteMappings, fake.validateCreateTcpRouteMappingArgsForCall[i].routerGroups, fake.validateCreateTcpRouteMappingArgsForCall[i].maxTTL
+	argsForCall := fake.validateCreateTcpRouteMappingArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturns(result1 *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingMutex.Unlock()
 	fake.ValidateCreateTcpRouteMappingStub = nil
 	fake.validateCreateTcpRouteMappingReturns = struct {
 		result1 *routing_api.Error
@@ -212,6 +181,8 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturns(result1 *ro
 }
 
 func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturnsOnCall(i int, result1 *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingMutex.Unlock()
 	fake.ValidateCreateTcpRouteMappingStub = nil
 	if fake.validateCreateTcpRouteMappingReturnsOnCall == nil {
 		fake.validateCreateTcpRouteMappingReturnsOnCall = make(map[int]struct {
@@ -223,26 +194,92 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturnsOnCall(i int
 	}{result1}
 }
 
-func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMapping(tcpRouteMappings []models.TcpRouteMapping) *routing_api.Error {
-	var tcpRouteMappingsCopy []models.TcpRouteMapping
-	if tcpRouteMappings != nil {
-		tcpRouteMappingsCopy = make([]models.TcpRouteMapping, len(tcpRouteMappings))
-		copy(tcpRouteMappingsCopy, tcpRouteMappings)
+func (fake *FakeRouteValidator) ValidateDelete(arg1 []models.Route) *routing_api.Error {
+	var arg1Copy []models.Route
+	if arg1 != nil {
+		arg1Copy = make([]models.Route, len(arg1))
+		copy(arg1Copy, arg1)
 	}
-	fake.validateDeleteTcpRouteMappingMutex.Lock()
-	ret, specificReturn := fake.validateDeleteTcpRouteMappingReturnsOnCall[len(fake.validateDeleteTcpRouteMappingArgsForCall)]
-	fake.validateDeleteTcpRouteMappingArgsForCall = append(fake.validateDeleteTcpRouteMappingArgsForCall, struct {
-		tcpRouteMappings []models.TcpRouteMapping
-	}{tcpRouteMappingsCopy})
-	fake.recordInvocation("ValidateDeleteTcpRouteMapping", []interface{}{tcpRouteMappingsCopy})
-	fake.validateDeleteTcpRouteMappingMutex.Unlock()
-	if fake.ValidateDeleteTcpRouteMappingStub != nil {
-		return fake.ValidateDeleteTcpRouteMappingStub(tcpRouteMappings)
+	fake.validateDeleteMutex.Lock()
+	ret, specificReturn := fake.validateDeleteReturnsOnCall[len(fake.validateDeleteArgsForCall)]
+	fake.validateDeleteArgsForCall = append(fake.validateDeleteArgsForCall, struct {
+		arg1 []models.Route
+	}{arg1Copy})
+	fake.recordInvocation("ValidateDelete", []interface{}{arg1Copy})
+	fake.validateDeleteMutex.Unlock()
+	if fake.ValidateDeleteStub != nil {
+		return fake.ValidateDeleteStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.validateDeleteTcpRouteMappingReturns.result1
+	fakeReturns := fake.validateDeleteReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteCallCount() int {
+	fake.validateDeleteMutex.RLock()
+	defer fake.validateDeleteMutex.RUnlock()
+	return len(fake.validateDeleteArgsForCall)
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteCalls(stub func([]models.Route) *routing_api.Error) {
+	fake.validateDeleteMutex.Lock()
+	defer fake.validateDeleteMutex.Unlock()
+	fake.ValidateDeleteStub = stub
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteArgsForCall(i int) []models.Route {
+	fake.validateDeleteMutex.RLock()
+	defer fake.validateDeleteMutex.RUnlock()
+	argsForCall := fake.validateDeleteArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteReturns(result1 *routing_api.Error) {
+	fake.validateDeleteMutex.Lock()
+	defer fake.validateDeleteMutex.Unlock()
+	fake.ValidateDeleteStub = nil
+	fake.validateDeleteReturns = struct {
+		result1 *routing_api.Error
+	}{result1}
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteReturnsOnCall(i int, result1 *routing_api.Error) {
+	fake.validateDeleteMutex.Lock()
+	defer fake.validateDeleteMutex.Unlock()
+	fake.ValidateDeleteStub = nil
+	if fake.validateDeleteReturnsOnCall == nil {
+		fake.validateDeleteReturnsOnCall = make(map[int]struct {
+			result1 *routing_api.Error
+		})
+	}
+	fake.validateDeleteReturnsOnCall[i] = struct {
+		result1 *routing_api.Error
+	}{result1}
+}
+
+func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMapping(arg1 []models.TcpRouteMapping) *routing_api.Error {
+	var arg1Copy []models.TcpRouteMapping
+	if arg1 != nil {
+		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.validateDeleteTcpRouteMappingMutex.Lock()
+	ret, specificReturn := fake.validateDeleteTcpRouteMappingReturnsOnCall[len(fake.validateDeleteTcpRouteMappingArgsForCall)]
+	fake.validateDeleteTcpRouteMappingArgsForCall = append(fake.validateDeleteTcpRouteMappingArgsForCall, struct {
+		arg1 []models.TcpRouteMapping
+	}{arg1Copy})
+	fake.recordInvocation("ValidateDeleteTcpRouteMapping", []interface{}{arg1Copy})
+	fake.validateDeleteTcpRouteMappingMutex.Unlock()
+	if fake.ValidateDeleteTcpRouteMappingStub != nil {
+		return fake.ValidateDeleteTcpRouteMappingStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.validateDeleteTcpRouteMappingReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingCallCount() int {
@@ -251,13 +288,22 @@ func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingCallCount() int {
 	return len(fake.validateDeleteTcpRouteMappingArgsForCall)
 }
 
+func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingCalls(stub func([]models.TcpRouteMapping) *routing_api.Error) {
+	fake.validateDeleteTcpRouteMappingMutex.Lock()
+	defer fake.validateDeleteTcpRouteMappingMutex.Unlock()
+	fake.ValidateDeleteTcpRouteMappingStub = stub
+}
+
 func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingArgsForCall(i int) []models.TcpRouteMapping {
 	fake.validateDeleteTcpRouteMappingMutex.RLock()
 	defer fake.validateDeleteTcpRouteMappingMutex.RUnlock()
-	return fake.validateDeleteTcpRouteMappingArgsForCall[i].tcpRouteMappings
+	argsForCall := fake.validateDeleteTcpRouteMappingArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingReturns(result1 *routing_api.Error) {
+	fake.validateDeleteTcpRouteMappingMutex.Lock()
+	defer fake.validateDeleteTcpRouteMappingMutex.Unlock()
 	fake.ValidateDeleteTcpRouteMappingStub = nil
 	fake.validateDeleteTcpRouteMappingReturns = struct {
 		result1 *routing_api.Error
@@ -265,6 +311,8 @@ func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingReturns(result1 *ro
 }
 
 func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMappingReturnsOnCall(i int, result1 *routing_api.Error) {
+	fake.validateDeleteTcpRouteMappingMutex.Lock()
+	defer fake.validateDeleteTcpRouteMappingMutex.Unlock()
 	fake.ValidateDeleteTcpRouteMappingStub = nil
 	if fake.validateDeleteTcpRouteMappingReturnsOnCall == nil {
 		fake.validateDeleteTcpRouteMappingReturnsOnCall = make(map[int]struct {
@@ -281,10 +329,10 @@ func (fake *FakeRouteValidator) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.validateCreateMutex.RLock()
 	defer fake.validateCreateMutex.RUnlock()
-	fake.validateDeleteMutex.RLock()
-	defer fake.validateDeleteMutex.RUnlock()
 	fake.validateCreateTcpRouteMappingMutex.RLock()
 	defer fake.validateCreateTcpRouteMappingMutex.RUnlock()
+	fake.validateDeleteMutex.RLock()
+	defer fake.validateDeleteMutex.RUnlock()
 	fake.validateDeleteTcpRouteMappingMutex.RLock()
 	defer fake.validateDeleteTcpRouteMappingMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/migration/fakes/fake_migration.go
+++ b/migration/fakes/fake_migration.go
@@ -22,8 +22,9 @@ type FakeMigration struct {
 	}
 	VersionStub        func() int
 	versionMutex       sync.RWMutex
-	versionArgsForCall []struct{}
-	versionReturns     struct {
+	versionArgsForCall []struct {
+	}
+	versionReturns struct {
 		result1 int
 	}
 	versionReturnsOnCall map[int]struct {
@@ -47,7 +48,8 @@ func (fake *FakeMigration) Run(arg1 *db.SqlDB) error {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.runReturns.result1
+	fakeReturns := fake.runReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeMigration) RunCallCount() int {
@@ -56,13 +58,22 @@ func (fake *FakeMigration) RunCallCount() int {
 	return len(fake.runArgsForCall)
 }
 
+func (fake *FakeMigration) RunCalls(stub func(*db.SqlDB) error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
+	fake.RunStub = stub
+}
+
 func (fake *FakeMigration) RunArgsForCall(i int) *db.SqlDB {
 	fake.runMutex.RLock()
 	defer fake.runMutex.RUnlock()
-	return fake.runArgsForCall[i].arg1
+	argsForCall := fake.runArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeMigration) RunReturns(result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	fake.runReturns = struct {
 		result1 error
@@ -70,6 +81,8 @@ func (fake *FakeMigration) RunReturns(result1 error) {
 }
 
 func (fake *FakeMigration) RunReturnsOnCall(i int, result1 error) {
+	fake.runMutex.Lock()
+	defer fake.runMutex.Unlock()
 	fake.RunStub = nil
 	if fake.runReturnsOnCall == nil {
 		fake.runReturnsOnCall = make(map[int]struct {
@@ -84,7 +97,8 @@ func (fake *FakeMigration) RunReturnsOnCall(i int, result1 error) {
 func (fake *FakeMigration) Version() int {
 	fake.versionMutex.Lock()
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
-	fake.versionArgsForCall = append(fake.versionArgsForCall, struct{}{})
+	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
 	if fake.VersionStub != nil {
@@ -93,7 +107,8 @@ func (fake *FakeMigration) Version() int {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.versionReturns.result1
+	fakeReturns := fake.versionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeMigration) VersionCallCount() int {
@@ -102,7 +117,15 @@ func (fake *FakeMigration) VersionCallCount() int {
 	return len(fake.versionArgsForCall)
 }
 
+func (fake *FakeMigration) VersionCalls(stub func() int) {
+	fake.versionMutex.Lock()
+	defer fake.versionMutex.Unlock()
+	fake.VersionStub = stub
+}
+
 func (fake *FakeMigration) VersionReturns(result1 int) {
+	fake.versionMutex.Lock()
+	defer fake.versionMutex.Unlock()
 	fake.VersionStub = nil
 	fake.versionReturns = struct {
 		result1 int
@@ -110,6 +133,8 @@ func (fake *FakeMigration) VersionReturns(result1 int) {
 }
 
 func (fake *FakeMigration) VersionReturnsOnCall(i int, result1 int) {
+	fake.versionMutex.Lock()
+	defer fake.versionMutex.Unlock()
 	fake.VersionStub = nil
 	if fake.versionReturnsOnCall == nil {
 		fake.versionReturnsOnCall = make(map[int]struct {

--- a/routes.go
+++ b/routes.go
@@ -10,6 +10,7 @@ const (
 	ListRouterGroups      = "ListRouterGroups"
 	UpdateRouterGroup     = "UpdateRouterGroup"
 	CreateRouterGroup     = "CreateRouterGroup"
+	DeleteRouterGroup     = "DeleteRouterGroup"
 	UpsertTcpRouteMapping = "UpsertTcpRouteMapping"
 	DeleteTcpRouteMapping = "DeleteTcpRouteMapping"
 	ListTcpRouteMapping   = "ListTcpRouteMapping"
@@ -21,6 +22,7 @@ var RoutesMap = map[string]rata.Route{UpsertRoute: {Path: "/routing/v1/routes", 
 	ListRoute:             {Path: "/routing/v1/routes", Method: "GET", Name: ListRoute},
 	EventStreamRoute:      {Path: "/routing/v1/events", Method: "GET", Name: EventStreamRoute},
 	CreateRouterGroup:     {Path: "/routing/v1/router_groups", Method: "POST", Name: CreateRouterGroup},
+	DeleteRouterGroup:     {Path: "/routing/v1/router_groups/:guid", Method: "DELETE", Name: DeleteRouterGroup},
 	ListRouterGroups:      {Path: "/routing/v1/router_groups", Method: "GET", Name: ListRouterGroups},
 	UpdateRouterGroup:     {Path: "/routing/v1/router_groups/:guid", Method: "PUT", Name: UpdateRouterGroup},
 	UpsertTcpRouteMapping: {Path: "/routing/v1/tcp_routes/create", Method: "POST", Name: UpsertTcpRouteMapping},


### PR DESCRIPTION
Currently, there are Create/Read/Update endpoints for Router Groups, however there is no support for a Delete endpoint. Such endpoints exist for other Routing API resources, such as Routes & TCP Route Mappings.

This PR adds the Delete endpoint for Router Groups.

Co-authored-by: Andrea Nodari <anodari@pivotal.io>

cc @nodo