### PR TITLE
add runtime check when updating or creating router_groups

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -70,6 +70,7 @@ type Config struct {
 	StatsdClientFlushInterval       time.Duration             `yaml:"-"`
 	OAuth                           OAuthConfig               `yaml:"oauth"`
 	RouterGroups                    models.RouterGroups       `yaml:"router_groups"`
+	ReservedSystemComponentPorts    []int                     `yaml:"reserved_system_component_ports"`
 	SqlDB                           SqlDB                     `yaml:"sqldb"`
 	Locket                          locket.ClientLocketConfig `yaml:"locket"`
 	UUID                            string                    `yaml:"uuid"`
@@ -140,6 +141,11 @@ func (cfg *Config) validate(authDisabled bool) error {
 		return fmt.Errorf("invalid API mTLS listen port: %s", err)
 	}
 
+	if err := validateReservedPorts(cfg.ReservedSystemComponentPorts); err != nil {
+		return err
+	}
+	models.ReservedSystemComponentPorts = cfg.ReservedSystemComponentPorts
+
 	if cfg.Locket.LocketAddress == "" {
 		return errors.New("locket address is required")
 	}
@@ -156,6 +162,15 @@ func validatePort(port int) error {
 		return fmt.Errorf("port number is invalid: %d (1-65535)", port)
 	}
 
+	return nil
+}
+
+func validateReservedPorts(ports []int) error {
+	for _, port := range ports {
+		if port < 0 || port > 65535 {
+			return fmt.Errorf("Invalid reserved system component port '%d'. Ports must be between 0 and 65535.", port)
+		}
+	}
 	return nil
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Config", func() {
 					Expect(cfg.API.MTLSClientCAPath).To(Equal("client ca file path"))
 					Expect(cfg.API.MTLSServerCertPath).To(Equal("server cert file path"))
 					Expect(cfg.API.MTLSServerKeyPath).To(Equal("server key file path"))
+					Expect(cfg.ReservedSystemComponentPorts).To(Equal([]int{5555, 6666}))
 				})
 
 				Context("when there is no token endpoint specified", func() {
@@ -500,6 +501,32 @@ var _ = Describe("Config", func() {
 					cfg, err := config.NewConfigFromBytes(testConfig, true)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cfg.RouterGroups).To(BeNil())
+				})
+			})
+		})
+
+		Context("when reserved_system_component_ports are provided", func() {
+			Context("when a port is too high", func() {
+				BeforeEach(func() {
+					validHash["reserved_system_component_ports"] = []int{1234, 70000, 5555}
+				})
+
+				It("returns an error", func() {
+					_, err := config.NewConfigFromBytes(testConfig, true)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Invalid reserved system component port '70000'. Ports must be between 0 and 65535."))
+				})
+			})
+
+			Context("when a port is too low", func() {
+				BeforeEach(func() {
+					validHash["reserved_system_component_ports"] = []int{1234, -10, 5555}
+				})
+
+				It("returns an error", func() {
+					_, err := config.NewConfigFromBytes(testConfig, true)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Invalid reserved system component port '-10'. Ports must be between 0 and 65535."))
 				})
 			})
 		})

--- a/example_config/example.yml
+++ b/example_config/example.yml
@@ -43,3 +43,6 @@ locket:
   locket_ca_cert_file: "some-locket-ca-cert"
   locket_client_cert_file: "some-locket-client-cert"
   locket_client_key_file: "some-locket-client-key"
+reserved_system_component_ports:
+  - 5555
+  - 6666

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -157,6 +157,33 @@ var _ = Describe("Models", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("Missing reservable_ports in router group: router-group-1"))
 			})
+
+			Context("when there are reserved system component ports", func(){
+				BeforeEach(func(){
+					ReservedSystemComponentPorts = []int{5555, 6666, 7777}
+				})
+
+				It("succeeds when the ports don't overlap", func(){
+					rg = RouterGroup{
+						Name:            "router-group-1",
+						Type:            "tcp",
+						ReservablePorts: "1025-2025",
+					}
+					err := rg.Validate()
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("fails when the ports overlap", func(){
+					rg = RouterGroup{
+						Name:            "router-group-1",
+						Type:            "tcp",
+						ReservablePorts: "5000-6000",
+					}
+					err := rg.Validate()
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("Invalid ports. Reservable ports must not include the following reserved system component ports: [5555 6666 7777]."))
+				})
+			})
 		})
 	})
 

--- a/models/router_groups.go
+++ b/models/router_groups.go
@@ -11,6 +11,8 @@ var InvalidPortError = errors.New("Port must be between 1024 and 65535")
 
 type RouterGroupType string
 
+var ReservedSystemComponentPorts = []int{}
+
 const (
 	RouterGroup_TCP  RouterGroupType = "tcp"
 	RouterGroup_HTTP RouterGroupType = "http"
@@ -168,7 +170,15 @@ func (p ReservablePorts) Validate() error {
 			}
 		}
 	}
-
+	// check if ports overlap with reservedSystemComponentPorts
+	for _, r1 := range portRanges {
+		for _, reservedPort := range ReservedSystemComponentPorts {
+			if uint64(reservedPort) >= r1.start && uint64(reservedPort) <= r1.end {
+				errMsg := fmt.Sprintf("Invalid ports. Reservable ports must not include the following reserved system component ports: %v.", ReservedSystemComponentPorts)
+				return errors.New(errMsg)
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
* make sure they don't overlap with system component ports
* see docs in routing-release for more info: https://github.com/cloudfoundry/routing-release/commit/83448037836e6f81a0afe3fdef2b2ac5bbf33c7d
* fixes this issue: https://github.com/cloudfoundry/routing-release/issues/184
* [#176681696](https://www.pivotaltracker.com/story/show/176681696)

Co-authored-by: Ben Fuller benjaminf@vmware.com
Co-authored-by: Kaitlin Barrer kbarrer@vmware.com
Co-authored-by: Renee Chu reneec@vmware.com