### PR TITLE
Stop emitting update events for empty upserts

### DIFF
--- a/db/db_sql.go
+++ b/db/db_sql.go
@@ -497,6 +497,11 @@ func (s *SqlDB) SaveTcpRouteMapping(tcpRouteMapping models.TcpRouteMapping) erro
 		if err != nil {
 			return err
 		}
+
+		if newTcpRouteMapping.Matches(existingTcpRouteMapping) {
+			return nil
+		}
+
 		return s.emitEvent(UpdateEvent, newTcpRouteMapping)
 	}
 

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -741,13 +741,11 @@ var _ = Describe("SqlDB", func() {
 				routerGroupId string
 				err           error
 				tcpRoute      models.TcpRouteMapping
-				ttl           int
 			)
 
 			BeforeEach(func() {
 				routerGroupId = newUuid()
-				ttl = 5
-				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, ttl)
+				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
 			})
 
 			AfterEach(func() {
@@ -1436,7 +1434,15 @@ var _ = Describe("SqlDB", func() {
 				It("should return an update watch event", func() {
 					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
 
-					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
+					updatedTcpRoute := models.NewTcpRouteMapping(
+						tcpRoute.RouterGroupGuid,
+						tcpRoute.ExternalPort,
+						tcpRoute.HostIP,
+						tcpRoute.HostPort,
+						*tcpRoute.TTL+1,
+					)
+
+					err = sqlDB.SaveTcpRouteMapping(updatedTcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
 					var event db.Event

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -825,7 +825,7 @@ var _ = Describe("SqlDB", func() {
 					})
 				})
 
-				FContext("and the update is a no-op", func() {
+				Context("and the update is a no-op", func() {
 					It("does not emit an update event", func() {
 						eventChan, errChan, _ := sqlDB.WatchChanges(db.TCP_WATCH)
 


### PR DESCRIPTION
This will seriously reduce the volume of events published to the event stream and consumed by the routers.