### PR TITLE
Stop Updating the modificationIndex on routes if they haven't changed.

### DIFF
--- a/models/models_test.go
+++ b/models/models_test.go
@@ -395,6 +395,63 @@ var _ = Describe("Models", func() {
 			route.ModificationTag = tag
 		})
 
+		Describe("Match", func() {
+			url := "https://example.com"
+			logGuid := "log-guid"
+			routeSvcUrl := "svcUrl"
+			ip := "10.10.10.10"
+			port := uint16(1234)
+			ttl := 5
+
+			It("Matches if values are the same", func() {
+				tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+				tcpRouteMapping2 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+				Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeTrue())
+			})
+			Context("When url is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute("blarg", port, ip, logGuid, routeSvcUrl, ttl)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("When port is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute(url, uint16(4321), ip, logGuid, routeSvcUrl, ttl)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("When ip is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute(url, port, "20.20.20.20", logGuid, routeSvcUrl, ttl)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("When logGuid is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute(url, port, ip, "new-guid", routeSvcUrl, ttl)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("When routeSvcUrl is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute(url, port, ip, logGuid, "newRtSvc", ttl)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("When ttl is different", func() {
+				It("doesn't match", func() {
+					tcpRouteMapping1 := NewRoute(url, port, ip, logGuid, routeSvcUrl, ttl)
+					tcpRouteMapping2 := NewRoute(url, port, ip, logGuid, routeSvcUrl, 10)
+					Expect(tcpRouteMapping1.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+		})
+
 		Describe("SetDefaults", func() {
 			JustBeforeEach(func() {
 				route.SetDefaults(120)

--- a/models/route.go
+++ b/models/route.go
@@ -3,7 +3,7 @@ package models
 import (
 	"time"
 
-	"github.com/nu7hatch/gouuid"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 type Route struct {
@@ -77,6 +77,15 @@ func (r Route) GetTTL() int {
 		return 0
 	}
 	return *r.TTL
+}
+
+func (r Route) Matches(other Route) bool {
+	return r.Port == other.Port &&
+		r.IP == other.IP &&
+		r.Route == other.Route &&
+		r.LogGuid == other.LogGuid &&
+		r.RouteServiceUrl == other.RouteServiceUrl &&
+		*r.TTL == *other.TTL
 }
 
 func (r *Route) SetDefaults(defaultTTL int) {


### PR DESCRIPTION
The contract with consumers of routing-api indicates that if the
modification index is newer than the previous, and guids are the same,
the old route should be replaced with the new one.

However, routing-api is updating that index regardless of whether any
changes occurred to the route info (just a heartbeat). This affected
both TCP + HTTP routes.

We no longer increment the modification tag unless the new route is
substantively different from the previous. This also ensures that TCP
and HTTP modification tag processing + event emitting behaviors are
in-line with eachother (this behavior diverged in
7ff498aff2f4a6547ad1e247bccf0ac0e5807e63, when we stopped emitting
upsert events for no-op changes).