### PR TITLE
Always emit UpdateEvent, even when upsert is empty

### DIFF
--- a/db/db_sql.go
+++ b/db/db_sql.go
@@ -508,11 +508,6 @@ func (s *SqlDB) SaveTcpRouteMapping(tcpRouteMapping models.TcpRouteMapping) erro
 		if err != nil {
 			return err
 		}
-
-		if newTcpRouteMapping.Matches(existingTcpRouteMapping) {
-			return nil
-		}
-
 		return s.emitEvent(UpdateEvent, newTcpRouteMapping)
 	}
 

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -825,16 +825,6 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				Context("and the update is a no-op", func() {
-					It("does not emit an update event", func() {
-						eventChan, errChan, _ := sqlDB.WatchChanges(db.TCP_WATCH)
-
-						err := sqlDB.SaveTcpRouteMapping(tcpRoute)
-						Expect(err).ToNot(HaveOccurred())
-
-						Consistently(errChan, 5).Should(Not(Receive()))
-						Consistently(eventChan, 5).Should(Not(Receive()))
-					})
-
 					It("updates the expiry using the previous TTL", func() {
 						var dbTcpRoute models.TcpRouteMapping
 						err = sqlDB.Client.Where("host_ip = ?", "127.0.0.1").First(&dbTcpRoute)


### PR DESCRIPTION
This reverts commit 7ff498aff2f4a6547ad1e247bccf0ac0e5807e63.

We still need to emit an UpdateEvent because the handler has gone
through the action of processing said update event. The catch is that
the Upsert even will *only* be applied _if_ the modification tag of the
route in the routing table is "succeeded by" the new event waiting to be
applied; in the case when the new and existing route mapping match,
nothing will be applied and haproxy will not reload unnecessarily.