### PR TITLE
Allow uaaclient callers to optionally pass in a protocol via

### DIFF
--- a/uaaclient/api_test.go
+++ b/uaaclient/api_test.go
@@ -1,0 +1,46 @@
+package uaaclient_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"code.cloudfoundry.org/lager"
+	"code.cloudfoundry.org/lager/lagertest"
+	"code.cloudfoundry.org/routing-api/uaaclient"
+)
+
+var _ = Describe("NewAPI", func() {
+	var (
+		config uaaclient.Config
+		logger lager.Logger
+	)
+
+	BeforeEach(func() {
+		config = uaaclient.Config{
+			SkipSSLValidation: true,
+			ClientName:        "client-name",
+			ClientSecret:      "client-secret",
+			TokenEndpoint:     "10.10.10.10",
+			Port:              8443,
+		}
+		logger = lagertest.NewTestLogger("test")
+	})
+
+	Context("when protocol is specified", func() {
+		BeforeEach(func() {
+			config.Protocol = "http"
+		})
+		It("returns an api obj using the right protocol", func() {
+			api, err := uaaclient.NewAPI(config, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(api.TargetURL.String()).To(Equal("http://10.10.10.10:8443"))
+		})
+	})
+	Context("when protocol is not specified", func() {
+		It("returns an api obj using the right protocol", func() {
+			api, err := uaaclient.NewAPI(config, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(api.TargetURL.String()).To(Equal("https://10.10.10.10:8443"))
+		})
+	})
+})

--- a/uaaclient/token_fetcher.go
+++ b/uaaclient/token_fetcher.go
@@ -31,7 +31,7 @@ func NewTokenFetcher(
 		return &noOpTokenFetcher{}, nil
 	}
 
-	api, err := newAPI(cfg, logger)
+	api, err := NewAPI(cfg, logger)
 	if err != nil {
 		logger.Error("Failed to create UAA client", err)
 		return nil, err

--- a/uaaclient/token_validator.go
+++ b/uaaclient/token_validator.go
@@ -21,7 +21,7 @@ func NewTokenValidator(devMode bool, cfg Config, logger lager.Logger) (TokenVali
 		return &noOpTokenValidator{}, nil
 	}
 
-	api, err := newAPI(cfg, logger)
+	api, err := NewAPI(cfg, logger)
 	if err != nil {
 		logger.Error("Failed to create UAA client", err)
 		return nil, err


### PR DESCRIPTION
the config object.

Needed to properly test route-registrar changes in [#184695943]