### PR TITLE
Genericize test setup for postgres too

### DIFF
--- a/cmd/routing-api/main_test.go
+++ b/cmd/routing-api/main_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Main", func() {
 			rapiConfig := getRoutingAPIConfig(defaultConfig)
 			connectionString, err := db.ConnectionString(&rapiConfig.SqlDB)
 			Expect(err).NotTo(HaveOccurred())
-			gormDB, err := gorm.Open("mysql", connectionString)
+			gormDB, err := gorm.Open(rapiConfig.SqlDB.Type, connectionString)
 			Expect(err).NotTo(HaveOccurred())
 
 			getRoutes := func() string {
@@ -239,7 +239,7 @@ var _ = Describe("Main", func() {
 			}
 			connectionString, err := db.ConnectionString(&rapiConfig.SqlDB)
 			Expect(err).NotTo(HaveOccurred())
-			gormDB, err = gorm.Open("mysql", connectionString)
+			gormDB, err = gorm.Open(rapiConfig.SqlDB.Type, connectionString)
 			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -1878,53 +1878,24 @@ var _ = Describe("SqlDB", func() {
 
 		})
 	}
-
-	Describe("Test with Mysql", func() {
-		var (
-			err error
-		)
-
-		BeforeEach(func() {
-			sqlCfg = mysqlCfg
-			sqlDB, err = db.NewSqlDB(sqlCfg)
-			Expect(err).ToNot(HaveOccurred())
-			err = migration.NewV0InitMigration().Run(sqlDB)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
+	Describe("DB Connection Configuration", func() {
 		MySQLConnectionString()
-		CleanupRoutes()
-		WatcherRouteChanges()
-		DeleteRoute()
-		ReadRoute()
-		SaveRoute()
-		DeleteTcpRouteMapping()
-		ReadTcpRouteMappings()
-		ReadFilteredTcpRouteMappings()
-		SaveTcpRouteMapping()
-		ReadRouterGroup()
-		ReadRouterGroupByName()
-		ReadRouterGroups()
-		SaveRouterGroup()
-		DeleteRouterGroup()
-		Connection()
-		FindExpiredRoutes()
+		PostgresConnectionString()
 	})
 
-	Describe("Test with Postgres", func() {
+	Describe("Test", func() {
 		var (
 			err error
 		)
 
 		BeforeEach(func() {
-			sqlCfg = postgresCfg
+			sqlCfg = databaseCfg
 			sqlDB, err = db.NewSqlDB(sqlCfg)
 			Expect(err).ToNot(HaveOccurred())
 			err = migration.NewV0InitMigration().Run(sqlDB)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		PostgresConnectionString()
 		CleanupRoutes()
 		WatcherRouteChanges()
 		DeleteRoute()
@@ -1942,7 +1913,6 @@ var _ = Describe("SqlDB", func() {
 		Connection()
 		FindExpiredRoutes()
 	})
-
 })
 
 func newUuid() string {

--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -11,10 +11,8 @@ import (
 )
 
 var (
-	mysqlCfg          *config.SqlDB
-	postgresCfg       *config.SqlDB
-	mysqlAllocator    testrunner.DbAllocator
-	postgresAllocator testrunner.DbAllocator
+	databaseCfg       *config.SqlDB
+	databaseAllocator testrunner.DbAllocator
 )
 
 func TestDB(t *testing.T) {
@@ -25,25 +23,18 @@ func TestDB(t *testing.T) {
 var _ = BeforeSuite(func() {
 	var err error
 
-	postgresAllocator = testrunner.NewPostgresAllocator()
-	postgresCfg, err = postgresAllocator.Create()
-	Expect(err).ToNot(HaveOccurred(), "error occurred starting postgres client, is postgres running?")
-	mysqlAllocator = testrunner.NewMySQLAllocator()
-	mysqlCfg, err = mysqlAllocator.Create()
-	Expect(err).ToNot(HaveOccurred(), "error occurred starting mysql client, is mysql running?")
+	databaseAllocator = testrunner.NewDbAllocator()
+	databaseCfg, err = databaseAllocator.Create()
+	Expect(err).ToNot(HaveOccurred(), "error occurred starting database client, is the database running?")
 })
 
 var _ = AfterSuite(func() {
-	err := mysqlAllocator.Delete()
+	err := databaseAllocator.Delete()
 	Expect(err).ToNot(HaveOccurred())
 
-	err = postgresAllocator.Delete()
-	Expect(err).ToNot(HaveOccurred())
 })
 
 var _ = BeforeEach(func() {
-	err := mysqlAllocator.Reset()
-	Expect(err).ToNot(HaveOccurred())
-	err = postgresAllocator.Reset()
+	err := databaseAllocator.Reset()
 	Expect(err).ToNot(HaveOccurred())
 })

--- a/migration/V0_init_migration_test.go
+++ b/migration/V0_init_migration_test.go
@@ -12,14 +12,14 @@ import (
 
 var _ = Describe("V0InitMigration", func() {
 	var (
-		mysqlAllocator testrunner.DbAllocator
-		dbClient       db.Client
-		sqlDB          *db.SqlDB
-		err            error
+		dbAllocator testrunner.DbAllocator
+		dbClient    db.Client
+		sqlDB       *db.SqlDB
+		err         error
 	)
 	BeforeEach(func() {
-		mysqlAllocator = testrunner.NewMySQLAllocator()
-		sqlCfg, err := mysqlAllocator.Create()
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 
 		sqlDB, err = db.NewSqlDB(sqlCfg)
@@ -28,7 +28,7 @@ var _ = Describe("V0InitMigration", func() {
 	})
 
 	AfterEach(func() {
-		err := mysqlAllocator.Delete()
+		err := dbAllocator.Delete()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/migration/V2_update_rg_migration_test.go
+++ b/migration/V2_update_rg_migration_test.go
@@ -1,6 +1,8 @@
 package migration_test
 
 import (
+	"strings"
+
 	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
@@ -12,13 +14,13 @@ import (
 
 var _ = Describe("V2UpdateRgMigration", func() {
 	var (
-		sqlDB          *db.SqlDB
-		mysqlAllocator testrunner.DbAllocator
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
 	)
 
 	BeforeEach(func() {
-		mysqlAllocator = testrunner.NewMySQLAllocator()
-		sqlCfg, err := mysqlAllocator.Create()
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 
 		sqlDB, err = db.NewSqlDB(sqlCfg)
@@ -29,7 +31,7 @@ var _ = Describe("V2UpdateRgMigration", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 	AfterEach(func() {
-		err := mysqlAllocator.Delete()
+		err := dbAllocator.Delete()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -72,7 +74,7 @@ var _ = Describe("V2UpdateRgMigration", func() {
 
 				_, err = sqlDB.Client.Create(&rg2)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("Duplicate"))
+				Expect(strings.ToLower(err.Error())).To(ContainSubstring("duplicate"))
 			})
 		})
 

--- a/migration/V3_update_tcp_route_migration_test.go
+++ b/migration/V3_update_tcp_route_migration_test.go
@@ -14,13 +14,13 @@ import (
 
 var _ = Describe("V3UpdateTcpRouteMigration", func() {
 	var (
-		sqlDB          *db.SqlDB
-		mysqlAllocator testrunner.DbAllocator
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
 	)
 
 	BeforeEach(func() {
-		mysqlAllocator = testrunner.NewMySQLAllocator()
-		sqlCfg, err := mysqlAllocator.Create()
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 
 		sqlDB, err = db.NewSqlDB(sqlCfg)
@@ -61,8 +61,9 @@ var _ = Describe("V3UpdateTcpRouteMigration", func() {
 		err = v2Migration.Run(sqlDB)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
 	AfterEach(func() {
-		err := mysqlAllocator.Delete()
+		err := dbAllocator.Delete()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/migration/V4_add_rg_uniq_idx_tcp_route_migration_test.go
+++ b/migration/V4_add_rg_uniq_idx_tcp_route_migration_test.go
@@ -16,12 +16,12 @@ import (
 var _ = Describe("V4AddRgUniqIdxTCPRouteMigration", func() {
 	var (
 		sqlDB          *db.SqlDB
-		mysqlAllocator testrunner.DbAllocator
+		dbAllocator testrunner.DbAllocator
 	)
 
 	BeforeEach(func() {
-		mysqlAllocator = testrunner.NewMySQLAllocator()
-		sqlCfg, err := mysqlAllocator.Create()
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 
 		sqlDB, err = db.NewSqlDB(sqlCfg)
@@ -29,7 +29,7 @@ var _ = Describe("V4AddRgUniqIdxTCPRouteMigration", func() {
 	})
 
 	AfterEach(func() {
-		err := mysqlAllocator.Delete()
+		err := dbAllocator.Delete()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/migration/V5_sni_hostname_migration_test.go
+++ b/migration/V5_sni_hostname_migration_test.go
@@ -6,7 +6,7 @@ import (
 	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
-	"code.cloudfoundry.org/routing-api/migration/v0"
+	v0 "code.cloudfoundry.org/routing-api/migration/v0"
 	"code.cloudfoundry.org/routing-api/models"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,13 +15,13 @@ import (
 
 var _ = Describe("V5SniHostnameMigration", func() {
 	var (
-		sqlDB          *db.SqlDB
-		mysqlAllocator testrunner.DbAllocator
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
 	)
 
 	BeforeEach(func() {
-		mysqlAllocator = testrunner.NewMySQLAllocator()
-		sqlCfg, err := mysqlAllocator.Create()
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 
 		sqlDB, err = db.NewSqlDB(sqlCfg)
@@ -29,7 +29,7 @@ var _ = Describe("V5SniHostnameMigration", func() {
 	})
 
 	AfterEach(func() {
-		err := mysqlAllocator.Delete()
+		err := dbAllocator.Delete()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -212,29 +212,9 @@ var _ = Describe("Migration", func() {
 		})
 	}
 
-	Describe("Test with Mysql", func() {
+	Describe("Test Migrations", func() {
 		BeforeEach(func() {
-			allocator = testrunner.NewMySQLAllocator()
-			sqlCfg, err := allocator.Create()
-			Expect(err).ToNot(HaveOccurred())
-
-			sqlDB, err = db.NewSqlDB(sqlCfg)
-			Expect(err).ToNot(HaveOccurred())
-			err = migration.NewV0InitMigration().Run(sqlDB)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		AfterEach(func() {
-			err := allocator.Delete()
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		TestMigrations()
-	})
-
-	Describe("Test with Postgres", func() {
-		BeforeEach(func() {
-			allocator = testrunner.NewPostgresAllocator()
+			allocator = testrunner.NewDbAllocator()
 			sqlCfg, err := allocator.Create()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
This was currently hardcoded to assume a mysql server. This changes that to allow a postgres server to be used with routing-api when running the tests. Also fixes an issue with mysql tests using indeterminate casing.

[#182691815](https://www.pivotaltracker.com/story/show/182691815)