### PR TITLE
Add fields to TCP Route Mappings support TLS backends.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -149,8 +149,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 
 		JustBeforeEach(func() {
@@ -357,8 +357,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 		JustBeforeEach(func() {
 			err = client.DeleteTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2})
@@ -531,8 +531,8 @@ var _ = Describe("Client", func() {
 			data             []byte
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when the server returns a valid response", func() {
@@ -1118,7 +1118,7 @@ var _ = Describe("Client", func() {
 		)
 
 		BeforeEach(func() {
-			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60)
+			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60002, "", nil, 60, models.ModificationTag{})
 
 			data, _ := json.Marshal(tcpRoute1)
 			event = sse.Event{

--- a/cmd/routing-api/api_test.go
+++ b/cmd/routing-api/api_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Routes API", func() {
 			BeforeEach(func() {
 				routerGroupGuid = getRouterGroupGuid()
 
-				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 60)
+				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 60, models.ModificationTag{})
 				eventStream, err = client.SubscribeToTcpEvents()
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -71,7 +71,7 @@ var _ = Describe("Routes API", func() {
 				done := make(chan interface{})
 				go func() {
 					defer close(done)
-					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 75)
+					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 75, models.ModificationTag{})
 
 					routesToInsert := []models.TcpRouteMapping{route1}
 
@@ -119,7 +119,7 @@ var _ = Describe("Routes API", func() {
 			})
 
 			It("gets events for expired routes", func() {
-				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1)
+				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 1, models.ModificationTag{})
 
 				err := client.UpsertTcpRouteMappings([]models.TcpRouteMapping{routeExpire})
 				Expect(err).NotTo(HaveOccurred())
@@ -334,8 +334,8 @@ var _ = Describe("Routes API", func() {
 			Context("POST", func() {
 				It("allows to create given tcp route mappings", func() {
 					var err error
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 3)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 
 					tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -351,7 +351,7 @@ var _ = Describe("Routes API", func() {
 				Context("when tcp route mappings already exist", func() {
 					BeforeEach(func() {
 						var err error
-						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
+						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60001, "", nil, 60, models.ModificationTag{})
 
 						tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1}
 						err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -399,8 +399,8 @@ var _ = Describe("Routes API", func() {
 				})
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
 
@@ -425,8 +425,8 @@ var _ = Describe("Routes API", func() {
 				)
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err := client.UpsertTcpRouteMappings(tcpRouteMappings)
 

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -746,7 +746,7 @@ var _ = Describe("SqlDB", func() {
 
 			BeforeEach(func() {
 				routerGroupId = newUuid()
-				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
+				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, models.ModificationTag{})
 			})
 
 			AfterEach(func() {
@@ -802,7 +802,7 @@ var _ = Describe("SqlDB", func() {
 					)
 					BeforeEach(func() {
 						routerGroupId2 = newUuid()
-						tcpRoute2 = models.NewTcpRouteMapping(routerGroupId2, 3056, "127.0.0.1", 2990, 5)
+						tcpRoute2 = models.NewTcpRouteMapping(routerGroupId2, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, models.ModificationTag{})
 					})
 
 					AfterEach(func() {
@@ -888,7 +888,7 @@ var _ = Describe("SqlDB", func() {
 				BeforeEach(func() {
 					routerGroupId = newUuid()
 					modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
+					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, modTag)
 					tcpRoute.ModificationTag = modTag
 					tcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
@@ -916,8 +916,7 @@ var _ = Describe("SqlDB", func() {
 
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-						expiredTcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, -9)
-						expiredTcpRoute.ModificationTag = modTag
+						expiredTcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, -9, modTag)
 						expiredTcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(expiredTcpRoute)
 						Expect(err).NotTo(HaveOccurred())
 						_, err = sqlDB.Client.Create(&expiredTcpRouteWithModel)
@@ -972,7 +971,7 @@ var _ = Describe("SqlDB", func() {
 				)
 
 				createTcpRouteWithIsoSeg := func(externalPort uint16, routerGroupID string, ttl int, isoSeg string) {
-					tcpRoute := models.NewTcpRouteMapping(routerGroupID, externalPort, "127.0.0.1", 2990, ttl)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupID, 3056, "127.0.0.1", 2990, 2991, "", nil, ttl, models.ModificationTag{})
 					tcpRoute.IsolationSegment = isoSeg
 					tcpRoute.ModificationTag = models.ModificationTag{Guid: "some-tag", Index: 10}
 					tcpRouteWithModel, err := models.NewTcpRouteMappingWithModel(tcpRoute)
@@ -1055,8 +1054,7 @@ var _ = Describe("SqlDB", func() {
 			BeforeEach(func() {
 				routerGroupId = newUuid()
 				modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
-				tcpRoute.ModificationTag = modTag
+				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "instanceId", nil, 5, modTag)
 				tcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1089,8 +1087,7 @@ var _ = Describe("SqlDB", func() {
 
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-						tcpRoute2 := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 5)
-						tcpRoute2.ModificationTag = modTag
+						tcpRoute2 := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 5, modTag)
 						tcpRouteWithModel2, err = models.NewTcpRouteMappingWithModel(tcpRoute2)
 						Expect(err).ToNot(HaveOccurred())
 						_, err = sqlDB.Client.Create(&tcpRouteWithModel2)
@@ -1417,7 +1414,7 @@ var _ = Describe("SqlDB", func() {
 				)
 
 				BeforeEach(func() {
-					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1430,7 +1427,11 @@ var _ = Describe("SqlDB", func() {
 						tcpRoute.ExternalPort,
 						tcpRoute.HostIP,
 						tcpRoute.HostPort,
+						*tcpRoute.HostTLSPort,
+						tcpRoute.InstanceId,
+						tcpRoute.SniHostname,
 						*tcpRoute.TTL+1,
+						tcpRoute.ModificationTag,
 					)
 
 					err = sqlDB.SaveTcpRouteMapping(updatedTcpRoute)
@@ -1448,7 +1449,7 @@ var _ = Describe("SqlDB", func() {
 				It("should return an create watch event", func() {
 					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
 
-					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1462,7 +1463,7 @@ var _ = Describe("SqlDB", func() {
 
 			Context("when a route is deleted", func() {
 				It("should return an delete watch event", func() {
-					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err := sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1670,7 +1671,7 @@ var _ = Describe("SqlDB", func() {
 				var tcpRouteModel models.TcpRouteMapping
 
 				BeforeEach(func() {
-					tcpRoute := models.NewTcpRouteMapping("guid", 3555, "127.0.0.1", 7879, 2)
+					tcpRoute := models.NewTcpRouteMapping("guid", 3555, "127.0.0.1", 7879, 7880, "instanceId", nil, 2, models.ModificationTag{})
 					var err error
 					tcpRouteModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 					Expect(err).ToNot(HaveOccurred())
@@ -1709,7 +1710,7 @@ var _ = Describe("SqlDB", func() {
 						var tcpRoute models.TcpRouteMapping
 
 						BeforeEach(func() {
-							tcpRoute = models.NewTcpRouteMapping("guid", 3556, "127.0.0.1", 7879, 100)
+							tcpRoute = models.NewTcpRouteMapping("guid", 3556, "127.0.0.1", 7879, 7880, "instanceId", nil, 100, models.ModificationTag{})
 							err := sqlDB.SaveTcpRouteMapping(tcpRoute)
 							Expect(err).ToNot(HaveOccurred())
 

--- a/docs/api_docs.md
+++ b/docs/api_docs.md
@@ -240,17 +240,21 @@ curl -vvv -H "Authorization: bearer [uaa token]" http://api.system-domain.com/ro
 | `router_group_guid` | string          | GUID of the router group associated with this route.
 | `backend_port`      | integer         | Backend port. Must be greater than 0.
 | `backend_ip`        | string          | IP address of backend.
+| `backend_tls_port`  | integer         | Backend TLS port. If 0, backend TLS is disabled. If nil, backend TLS is not something the client knows about.
+| `instance_id`       | string          | Instance ID of the backend, used for TLS validation when backend TLS is enabled.
 | `port`              | integer         | External facing port for the TCP route.
-| `modification_tag`  | object     | See [Modification Tags](modification_tags.md).
+| `modification_tag`  | object          | See [Modification Tags](modification_tags.md).
 | `ttl`               | integer         | Time to live, in seconds. The mapping of backend to route will be pruned after this time.
-| `isolation_segment` | string | Isolation segment for the route. |
+| `isolation_segment` | string          | Isolation segment for the route. |
 
 #### Example Response:
 ```json
 [{
   "router_group_guid": "xyz789",
-  "backend_port": 60000,
   "backend_ip": "10.1.1.12",
+  "backend_port": 60000,
+  "backend_tls_port": 60001,
+  "instance_id", "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "port": 5200,
   "modification_tag":  {
     "guid": "cbdhb4e3-141d-4259-b0ac-99140e8998l0",
@@ -280,6 +284,8 @@ As routes have a TTL, clients must register routes periodically to keep them act
 | `port`                 | integer         | yes       | External facing port for the TCP route.
 | `backend_ip`           | string          | yes       | IP address of backend
 | `backend_port`         | integer         | yes       | Backend port. Must be greater than 0.
+| `backend_tls_port`     | integer         | no        | Backend TLS port. If 0, indicates no TLS. If not provided, indicates a client that doesn't know about backend TLS port support. Otherwise must be greater than 0.
+| `instance_id`          | string          | no        | Instance ID of the backend container. Used to validate the TLS cert of a backend.
 | `ttl`                  | integer         | yes       | Time to live, in seconds. The mapping of backend to route will be pruned after this time. Must be greater than 0 seconds and less than the configured value for max_ttl (default 120 seconds).
 | `modification_tag`     | object          | no        | See [Modification Tags](modification_tags.md).
 | `isolation_segment`    | string          | no        | Name of the isolation segment for the route.
@@ -293,6 +299,8 @@ curl -vvv -H "Authorization: bearer [uaa token]" -X POST http://api.system-domai
   "port": 5200,
   "backend_ip": "10.1.1.12",
   "backend_port": 60000,
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "ttl": 120,
   "modification_tag":  {
     "guid": "cbdhb4e3-141d-4259-b0ac-99140e8998l0",
@@ -308,6 +316,8 @@ curl -k -vvv -H "Authorization: bearer $uaa_token" -X POST https://api.system-do
   "port": 1121,
   "backend_ip": "10.0.8.5",
   "backend_port": 8888,
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "backend_sni_hostname":"teststst.asd.com",
   "ttl": 120
 }]'
@@ -333,6 +343,8 @@ Delete TCP Routes
 | `port`              | integer         | yes       | External facing port for the TCP route.
 | `backend_ip`        | string          | yes       | IP address of backend
 | `backend_port`      | integer         | yes       | Backend port. Must be greater than 0.
+| `backend_tls_port`  | integer         | no        | Backend TLS port. If 0, indicates no TLS. If not provided, indicates a client that doesn't know about backend TLS port support. Otherwise must be greater than 0.
+| `instance_id`       | string          | no        | Instance ID of the backend container. Used to validate the TLS cert of a backend.
 
 #### Example Request
 ```bash
@@ -342,6 +354,8 @@ curl -vvv -H "Authorization: bearer [uaa token]" -X POST http://api.system-domai
   "port": 5200,
   "backend_ip": "10.1.1.12",
   "backend_port": 60000
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
 }]'
 ```
 
@@ -374,11 +388,11 @@ curl -vvv -H "Authorization: bearer [uaa token]" http://api.system-domain.com/ro
 ```
 id: 0
 event: Upsert
-data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":1},"ttl":120}
+data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_tls_port":60001,"instance_id":"91860bfe-ecff-480d-8df4-0d1eb0295b04","backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":1},"ttl":120}
 
 id: 1
 event: Upsert
-data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":2},"ttl":120}
+data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_tls_port":60001,"instance_id":"91860bfe-ecff-480d-8df4-0d1eb0295b04","backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":2},"ttl":120}
 ```
 
 List HTTP Routes (Experimental)

--- a/event_source_test.go
+++ b/event_source_test.go
@@ -167,7 +167,7 @@ var _ = Describe("EventSource", func() {
 						rawEvent := sse.Event{
 							ID:    "1",
 							Name:  "Test",
-							Data:  []byte(`{"router_group_guid": "rguid1", "port":52000, "backend_port":60000,"backend_ip":"1.1.1.1","modification_tag":{"guid":"my-guid","index":5}}`),
+							Data:  []byte(`{"router_group_guid": "rguid1", "port":52000, "backend_port":60000,"backend_ip":"1.1.1.1","modification_tag":{"guid":"my-guid","index":5},"instance_id":"instance-id","backend_tls_port":60001}`),
 							Retry: 1,
 						}
 
@@ -175,8 +175,7 @@ var _ = Describe("EventSource", func() {
 							Guid:  "my-guid",
 							Index: 5,
 						}
-						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 5)
-						tcpMapping.ModificationTag = modTag
+						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60001, "instance-id", nil, 5, modTag)
 						tcpMapping.TTL = nil
 
 						expectedEvent := routing_api.TcpEvent{

--- a/handlers/tcp_route_mappings_handler_test.go
+++ b/handlers/tcp_route_mappings_handler_test.go
@@ -79,6 +79,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 							"router_group_guid": "router-group-guid-001",
 							"backend_ip":        "1.2.3.4",
 							"backend_port":      float64(60000),
+							"backend_tls_port":  nil,
+							"instance_id":       "",
 							"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 							"ttl":               float64(120),
 							"isolation_segment": "some-iso-seg",
@@ -112,6 +114,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 						"router_group_guid": "router-group-guid-001",
 						"backend_ip":        "1.2.3.4",
 						"backend_port":      float64(60000),
+						"backend_tls_port":  nil,
+						"instance_id":       "",
 						"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 						"ttl":               float64(120),
 						"isolation_segment": "some-iso-seg",
@@ -155,6 +159,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 						"router_group_guid": "router-group-guid-001",
 						"backend_ip":        "1.2.3.4",
 						"backend_port":      float64(60000),
+						"backend_tls_port":  nil,
+						"instance_id":       "",
 						"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 						"ttl":               float64(maxTTL),
 						"isolation_segment": "",
@@ -172,7 +178,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 				var tcpMappings []models.TcpRouteMapping
 
 				BeforeEach(func() {
-					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
+					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
 					tcpMappings = []models.TcpRouteMapping{tcpMapping}
 				})
 
@@ -216,6 +222,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 							"router_group_guid": "router-group-guid-001",
 							"backend_ip":        "1.2.3.4",
 							"backend_port":      float64(60000),
+							"backend_tls_port":  float64(60001),
+							"instance_id":       "instanceId",
 							"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 							"ttl":               float64(60),
 							"isolation_segment": "",
@@ -309,7 +317,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 					tcpMappings  []models.TcpRouteMapping
 				)
 				BeforeEach(func() {
-					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
+					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
 					tcpMappings = []models.TcpRouteMapping{tcpMapping}
 					currentCount = metrics.GetTokenErrors()
 					fakeClient.ValidateTokenReturns(errors.New("Not valid"))
@@ -344,8 +352,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			)
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 55)
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 55)
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadTcpRouteMappingsReturns(tcpRoutes, nil)
 			})
@@ -362,6 +370,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52000,
 								"backend_ip": "1.2.3.4",
 								"backend_port": 60000,
+								"backend_tls_port": 60002,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -374,6 +384,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52001,
 								"backend_ip": "1.2.3.5",
 								"backend_port": 60001,
+								"backend_tls_port": 60003,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -391,8 +403,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			)
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 55)
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 55)
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
 				mapping2.IsolationSegment = "is1"
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadFilteredTcpRouteMappingsReturns(tcpRoutes, nil)
@@ -418,6 +430,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52000,
 								"backend_ip": "1.2.3.4",
 								"backend_port": 60000,
+								"backend_tls_port": 60002,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -430,6 +444,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52001,
 								"backend_ip": "1.2.3.5",
 								"backend_port": 60001,
+								"backend_tls_port": 60003,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -458,6 +474,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52000,
 								"backend_ip": "1.2.3.4",
 								"backend_port": 60000,
+								"backend_tls_port": 60002,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -470,6 +488,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52001,
 								"backend_ip": "1.2.3.5",
 								"backend_port": 60001,
+								"backend_tls_port": 60003,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -487,8 +507,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			)
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 55)
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 55)
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
 				mapping2.IsolationSegment = "is1"
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadTcpRouteMappingsReturns(tcpRoutes, nil)
@@ -509,6 +529,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52000,
 								"backend_ip": "1.2.3.4",
 								"backend_port": 60000,
+								"backend_tls_port": 60002,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -521,6 +543,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 								"port": 52001,
 								"backend_ip": "1.2.3.5",
 								"backend_port": 60001,
+								"backend_tls_port": 60003,
+								"instance_id": "instanceId",
 								"modification_tag": {
 									"guid": "",
 									"index": 0
@@ -586,7 +610,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			)
 
 			BeforeEach(func() {
-				tcpMapping = models.NewTcpRouteMapping("router-group-guid-002", 52001, "1.2.3.4", 60000, 60)
+				tcpMapping = models.NewTcpRouteMapping("router-group-guid-002", 52001, "1.2.3.4", 60000, 60002, "instanceId", nil, 60, models.ModificationTag{})
 				tcpMappings = []models.TcpRouteMapping{tcpMapping}
 			})
 
@@ -630,6 +654,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 						"router_group_guid": "router-group-guid-002",
 						"backend_ip":        "1.2.3.4",
 						"backend_port":      float64(60000),
+						"backend_tls_port":  float64(60002),
+						"instance_id":       "instanceId",
 						"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 						"ttl":               float64(60),
 						"isolation_segment": "",

--- a/handlers/validator_test.go
+++ b/handlers/validator_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Validator", func() {
 					ReservablePorts: "1024-65535",
 				},
 			}
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60)
+			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when valid tcp mapping is passed", func() {
@@ -297,7 +297,7 @@ var _ = Describe("Validator", func() {
 		)
 
 		BeforeEach(func() {
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60)
+			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when valid tcp mapping is passed", func() {

--- a/migration/V5_sni_hostname_migration.go
+++ b/migration/V5_sni_hostname_migration.go
@@ -22,7 +22,7 @@ func (v *V5SniHostnameMigration) Run(sqlDB *db.SqlDB) error {
 	if err != nil {
 		return err
 	}
-	err = sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	_, err = sqlDB.Client.Model(&models.TcpRouteMapping{}).AddUniqueIndex("idx_tcp_route", "router_group_guid", "host_port", "host_ip", "external_port", "sni_hostname")
 	if err != nil {
 		return err
 	}

--- a/migration/V6_tls_tcp_route.go
+++ b/migration/V6_tls_tcp_route.go
@@ -1,0 +1,34 @@
+package migration
+
+import (
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+type V6TCPTLSRoutes struct{}
+
+var _ Migration = new(V6TCPTLSRoutes)
+
+func NewV6TCPTLSRoutes() *V6TCPTLSRoutes {
+	return &V6TCPTLSRoutes{}
+}
+
+func (v *V6TCPTLSRoutes) Version() int {
+	return 6
+}
+
+func (v *V6TCPTLSRoutes) Run(sqlDB *db.SqlDB) error {
+	_, err := sqlDB.Client.Model(&models.TcpRouteMapping{}).RemoveIndex("idx_tcp_route")
+	if err != nil {
+		return err
+	}
+	err = sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	if err != nil {
+		return err
+	}
+	_, err = sqlDB.Client.Model(&models.TcpRouteMapping{}).AddUniqueIndex("idx_tcp_route", "router_group_guid", "host_port", "host_ip", "external_port", "sni_hostname", "host_tls_port")
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/migration/V6_tls_tcp_route_test.go
+++ b/migration/V6_tls_tcp_route_test.go
@@ -1,0 +1,164 @@
+package migration_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/migration"
+	v5 "code.cloudfoundry.org/routing-api/migration/v5"
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func ptrOfInt(i uint16) *uint16 {
+	return &i
+}
+
+var _ = Describe("V6TCPTLSRoutes", func() {
+	var (
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
+	)
+
+	BeforeEach(func() {
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
+		Expect(err).NotTo(HaveOccurred())
+
+		sqlDB, err = db.NewSqlDB(sqlCfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := dbAllocator.Delete()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	runTests := func() {
+		Context("After migration", func() {
+			BeforeEach(func() {
+				v6Migration := migration.NewV6TCPTLSRoutes()
+				err := v6Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-1"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     ptrOfInt(443),
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId1",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("allows adding the same TCP routes with different host TLS ports", func() {
+				sniHostname2 := "sniHostname2"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     ptrOfInt(444),
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId2",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname2,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).NotTo(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(2))
+			})
+
+			It("denies adding the same TCP routes with same host TLS ports", func() {
+				sniHostname1 := "sniHostname1"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     ptrOfInt(443),
+						InstanceId:      "instanceId2",
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).To(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+			})
+
+			It("denies adding the same TCP routes with different instance_ids", func() {
+				sniHostname1 := "sniHostname1"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     ptrOfInt(443),
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId2",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).To(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+			})
+		})
+	}
+
+	Describe("Version", func() {
+		It("returns 6 for the version", func() {
+			v6Migration := migration.NewV6TCPTLSRoutes()
+			Expect(v6Migration.Version()).To(Equal(6))
+		})
+	})
+
+	Describe("Run", func() {
+		Context("when there are existing tables with the old tcp_route model", func() {
+			BeforeEach(func() {
+				err := sqlDB.Client.AutoMigrate(&v5.RouterGroupDB{}, &v5.TcpRouteMapping{}, &v5.Route{})
+				Expect(err).ToNot(HaveOccurred())
+				v5Migration := migration.NewV5SniHostnameMigration()
+				err = v5Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+
+		Context("when the tables are newly created (by V0 init migration)", func() {
+			BeforeEach(func() {
+				v0Migration := migration.NewV0InitMigration()
+				err := v0Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+	})
+})

--- a/migration/v5/models.go
+++ b/migration/v5/models.go
@@ -1,0 +1,75 @@
+package v5
+
+import (
+	"time"
+)
+
+type Model struct {
+	Guid      string    `gorm:"primary_key" json:"-"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
+}
+
+type ModificationTag struct {
+	Guid  string `gorm:"column:modification_guid" json:"guid"`
+	Index uint32 `gorm:"column:modification_index" json:"index"`
+}
+
+type TcpRouteMapping struct {
+	Model
+	ExpiresAt time.Time `json:"-"`
+	TcpMappingEntity
+}
+
+func (TcpRouteMapping) TableName() string {
+	return "tcp_routes"
+}
+
+type TcpMappingEntity struct {
+	RouterGroupGuid  string  `gorm:"not null; unique_index:idx_tcp_route" json:"router_group_guid"`
+	HostPort         uint16  `gorm:"not null; unique_index:idx_tcp_route; type:int" json:"backend_port"`
+	HostIP           string  `gorm:"not null; unique_index:idx_tcp_route" json:"backend_ip"`
+	SniHostname      *string `gorm:"default:null; unique_index:idx_tcp_route" json:"backend_sni_hostname,omitempty"`
+	ExternalPort     uint16  `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
+	ModificationTag  `json:"modification_tag"`
+	TTL              *int   `json:"ttl,omitempty"`
+	IsolationSegment string `json:"isolation_segment"`
+}
+
+type Route struct {
+	Model
+	ExpiresAt time.Time `json:"-"`
+	RouteEntity
+}
+
+type RouteEntity struct {
+	Route           string `gorm:"not null; unique_index:idx_route" json:"route"`
+	Port            uint16 `gorm:"not null; unique_index:idx_route" json:"port"`
+	IP              string `gorm:"not null; unique_index:idx_route" json:"ip"`
+	TTL             *int   `json:"ttl"`
+	LogGuid         string `json:"log_guid"`
+	RouteServiceUrl string `gorm:"not null; unique_index:idx_route" json:"route_service_url,omitempty"`
+	ModificationTag `json:"modification_tag"`
+}
+
+type RouterGroupDB struct {
+	Model
+	Name            string
+	Type            string
+	ReservablePorts string
+}
+
+func (RouterGroupDB) TableName() string {
+	return "router_groups"
+}
+
+type RouterGroup struct {
+	Model
+	Guid            string          `json:"guid"`
+	Name            string          `json:"name"`
+	Type            RouterGroupType `json:"type"`
+	ReservablePorts ReservablePorts `json:"reservable_ports" yaml:"reservable_ports"`
+}
+
+type RouterGroupType string
+type ReservablePorts string

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -426,8 +426,7 @@ var _ = Describe("Models", func() {
 		BeforeEach(func() {
 			tag, err := NewModificationTag()
 			Expect(err).ToNot(HaveOccurred())
-			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 66)
-			route.ModificationTag = tag
+			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag)
 		})
 
 		Describe("SetDefaults", func() {


### PR DESCRIPTION

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

The HostTLSPort and InstanceId properties have been added to support TLS backends on TCP routes.

When HostTLSPort is nil, TCP routes can be assumed to be created by old clients that are unaware of TLS support. When 0, TLS is explicitly disabled. Positive values indicate the port that the backend is reachable at via TLS.

InstanceId is the identifier used to verify the backend TLS cert's hostname against, similar to how Gorouter handles Route Integrity.




Backward Compatibility
---------------
Sorta. The new fields are not required and backwards compatible, but there are public functions that we deleted and changed signatures on, after verifying that nothing outside of CF is importing them, and providing PRs to the projects that made use of them. 
