### PR TITLE
Fix failing tests from TLS changes

### DIFF
--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 var _ = Describe("SqlDB", func() {
-
 	var (
 		sqlCfg *config.SqlDB
 		sqlDB  *db.SqlDB
@@ -605,7 +604,6 @@ var _ = Describe("SqlDB", func() {
 					Expect(rg.ReservablePorts).To(Equal(routerGroup.ReservablePorts))
 					Expect(rg.Type).To(Equal(routerGroup.Type))
 				})
-
 			})
 
 			It("Can remove ReservablePorts", func() {
@@ -644,7 +642,6 @@ var _ = Describe("SqlDB", func() {
 				})
 			})
 		})
-
 	}
 
 	DeleteRouterGroup := func() {
@@ -779,7 +776,7 @@ var _ = Describe("SqlDB", func() {
 
 				It("refreshes the expiration time of the mapping", func() {
 					var dbTcpRoute models.TcpRouteMapping
-					var ttl = 9
+					ttl := 9
 					err = sqlDB.Client.Where("host_ip = ?", "127.0.0.1").First(&dbTcpRoute)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(dbTcpRoute).ToNot(BeNil())
@@ -1158,7 +1155,7 @@ var _ = Describe("SqlDB", func() {
 
 				It("refreshes the expiration time of the route", func() {
 					var dbRoute models.Route
-					var ttl = 9
+					ttl := 9
 					err = sqlDB.Client.Where("ip = ?", "127.0.0.1").First(&dbRoute)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(dbRoute).ToNot(BeNil())
@@ -1338,9 +1335,7 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				Context("when multiple routes exist", func() {
-					var (
-						routeWithModel2 models.Route
-					)
+					var routeWithModel2 models.Route
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
 						route := models.NewRoute("post_here", 7001, "127.0.0.1", "my-guid", "https://rs.com", 5)
@@ -1409,9 +1404,7 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when a tcp route is updated", func() {
-				var (
-					tcpRoute models.TcpRouteMapping
-				)
+				var tcpRoute models.TcpRouteMapping
 
 				BeforeEach(func() {
 					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
@@ -1507,15 +1500,12 @@ var _ = Describe("SqlDB", func() {
 
 					Consistently(event).ShouldNot(Receive())
 					Eventually(event).Should(BeClosed())
-
 				})
 			})
 		})
 
 		Describe("WatchChanges with http events", func() {
-			var (
-				err error
-			)
+			var err error
 
 			It("does not return an error when canceled", func() {
 				_, errors, cancel := sqlDB.WatchChanges(db.HTTP_WATCH)
@@ -1525,9 +1515,7 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when a http route is updated", func() {
-				var (
-					httpRoute models.Route
-				)
+				var httpRoute models.Route
 
 				BeforeEach(func() {
 					httpRoute = models.NewRoute("post_here", 7001, "127.0.0.1", "my-guid", "https://rs.com", 5)
@@ -1606,7 +1594,6 @@ var _ = Describe("SqlDB", func() {
 
 					Consistently(event).ShouldNot(Receive())
 					Eventually(event).Should(BeClosed())
-
 				})
 			})
 		})
@@ -1664,7 +1651,6 @@ var _ = Describe("SqlDB", func() {
 
 					Eventually(fakeClient.DeleteCallCount).Should(Equal(4))
 				})
-
 			})
 
 			Context("tcp routes", func() {
@@ -1685,7 +1671,6 @@ var _ = Describe("SqlDB", func() {
 
 				Context("when db connection is successful", func() {
 					Context("when all routes have expired", func() {
-
 						It("should prune the expired routes and log the number of pruned routes", func() {
 							Eventually(func() []models.TcpRouteMapping {
 								var tcpRoutes []models.TcpRouteMapping
@@ -1801,7 +1786,6 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when db throws an error", func() {
-
 				BeforeEach(func() {
 					err := sqlDB.Client.Close()
 					Expect(err).ToNot(HaveOccurred())
@@ -1829,7 +1813,6 @@ var _ = Describe("SqlDB", func() {
 				expiryTime = time.UnixMilli(1652378100300)
 				queryTime = time.UnixMilli(1652378100200)
 				fc = fakeclock.NewFakeClock(queryTime)
-
 			})
 			Context("tcpRoutes", func() {
 				BeforeEach(func() {
@@ -1877,7 +1860,6 @@ var _ = Describe("SqlDB", func() {
 					Expect(len(httpRoutes)).To(Equal(0))
 				})
 			})
-
 		})
 	}
 	Describe("DB Connection Configuration", func() {
@@ -1886,9 +1868,7 @@ var _ = Describe("SqlDB", func() {
 	})
 
 	Describe("Test", func() {
-		var (
-			err error
-		)
+		var err error
 
 		BeforeEach(func() {
 			sqlCfg = databaseCfg

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -56,7 +56,8 @@ func NewTcpRouteMapping(
 	instanceId string,
 	sniHostname *string,
 	ttl int,
-	modTag ModificationTag) TcpRouteMapping {
+	modTag ModificationTag,
+) TcpRouteMapping {
 	mapping := TcpRouteMapping{
 		TcpMappingEntity: TcpMappingEntity{
 			RouterGroupGuid: routerGroupGuid,
@@ -78,16 +79,31 @@ func (m TcpRouteMapping) String() string {
 }
 
 func (m TcpRouteMapping) Matches(other TcpRouteMapping) bool {
-	return m.RouterGroupGuid == other.RouterGroupGuid &&
-		m.ExternalPort == other.ExternalPort &&
-		m.HostIP == other.HostIP &&
-		m.HostPort == other.HostPort &&
-		((m.HostTLSPort == other.HostTLSPort) ||
-			m.HostTLSPort != 0 && other.HostTLSPort != 0) &&
-		m.InstanceId == other.InstanceId &&
-		*m.TTL == *other.TTL &&
-		((m.SniHostname == other.SniHostname) ||
-			m.SniHostname != nil && other.SniHostname != nil && *m.SniHostname == *other.SniHostname)
+	sameRouterGroupGuid := m.RouterGroupGuid == other.RouterGroupGuid
+	sameExternalPort := m.ExternalPort == other.ExternalPort
+	sameHostIP := m.HostIP == other.HostIP
+	sameHostPort := m.HostPort == other.HostPort
+	sameInstanceId := m.InstanceId == other.InstanceId
+	sameHostTLSPort := m.HostTLSPort == other.HostTLSPort
+
+	nilTTL := m.TTL == nil && other.TTL == nil
+	sameTTLPointer := m.TTL == other.TTL
+	sameTTLValue := m.TTL != nil && other.TTL != nil && *m.TTL == *other.TTL
+	sameTTL := nilTTL || sameTTLPointer || sameTTLValue
+
+	nilSniHostname := m.SniHostname == nil && other.SniHostname == nil
+	sameSniHostnamePointer := m.SniHostname == other.SniHostname
+	sameSniHostnameValue := m.SniHostname != nil && other.SniHostname != nil && *m.SniHostname == *other.SniHostname
+	sameSniHostname := nilSniHostname || sameSniHostnamePointer || sameSniHostnameValue
+
+	return sameRouterGroupGuid &&
+		sameExternalPort &&
+		sameHostIP &&
+		sameHostPort &&
+		sameInstanceId &&
+		sameTTL &&
+		sameHostTLSPort &&
+		sameSniHostname
 }
 
 func (t *TcpRouteMapping) SetDefaults(maxTTL int) {


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR fixes test failures from changing `HostTLSPort`'s type from `*uint` to `int`. `int` has the default value of `0` in Go and there are tests which test for `nil` for `HostTLSPort` because the default value for a pointer is `nil`. This PR changes the type for `HostTLSPort` from `int` to `*int` and also clarifies the logic for the function `func (m TcpRouteMapping) Matches(other TcpRouteMapping) bool` which was becoming difficult to understand. It also adds more checks for `TTL` which currently dereferences a pointer without checking for nil


Backward Compatibility
---------------
Breaking Change? **No**
