### PR TITLE
Allow backend port to be 0 when backend tls port is provided on a tcp…

### DIFF
--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -185,9 +185,15 @@ func validateTcpRouteMapping(tcpRouteMapping models.TcpRouteMapping, checkTTL bo
 		return &err
 	}
 
-	if tcpRouteMapping.HostPort <= 0 {
+	if tcpRouteMapping.HostPort <= 0 && tcpRouteMapping.HostTLSPort <= 0 {
 		err := routing_api.NewError(routing_api.TcpRouteMappingInvalidError,
 			"Each tcp mapping requires a positive backend port. RouteMapping=["+tcpRouteMapping.String()+"]")
+		return &err
+	}
+
+	if tcpRouteMapping.HostTLSPort > 65535 {
+		err := routing_api.NewError(routing_api.TcpRouteMappingInvalidError,
+			"Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535. RouteMapping=["+tcpRouteMapping.String()+"]")
 		return &err
 	}
 

--- a/handlers/validator_test.go
+++ b/handlers/validator_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Validator", func() {
 					ReservablePorts: "1024-65535",
 				},
 			}
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
+			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when valid tcp mapping is passed", func() {
@@ -232,13 +232,39 @@ var _ = Describe("Validator", func() {
 		})
 
 		Context("when invalid tcp route mappings are passed", func() {
-
-			It("blows up when a backend port is zero", func() {
-				tcpMapping.HostPort = 0
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+			Context("when there is no TLSPort provided", func() {
+				It("blows up when a backend port is zero", func() {
+					tcpMapping.HostPort = 0
+					err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+				})
+			})
+			Context("When there is a TLSPort provided", func() {
+				BeforeEach(func() {
+					tcpMapping.HostTLSPort = 6
+				})
+				Context("when host TLS port is > 65535", func() {
+					BeforeEach(func() {
+						tcpMapping.HostTLSPort = 65546
+					})
+					It("throws an error", func() {
+						err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+						Expect(err).ToNot(BeNil())
+						Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+						Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
+					})
+				})
+				Context("when host port is zero", func() {
+					BeforeEach(func() {
+						tcpMapping.HostPort = 0
+					})
+					It("does not error", func() {
+						err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
 			})
 
 			It("blows up when a external port is zero", func() {
@@ -297,7 +323,7 @@ var _ = Describe("Validator", func() {
 		)
 
 		BeforeEach(func() {
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
+			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when valid tcp mapping is passed", func() {
@@ -308,13 +334,39 @@ var _ = Describe("Validator", func() {
 		})
 
 		Context("when invalid tcp route mappings are passed", func() {
-
-			It("blows up when a backend port is zero", func() {
-				tcpMapping.HostPort = 0
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+			Context("when there is no TLSPort provided", func() {
+				It("blows up when a backend port is zero", func() {
+					tcpMapping.HostPort = 0
+					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+				})
+			})
+			Context("When there is a TLSPort provided", func() {
+				BeforeEach(func() {
+					tcpMapping.HostTLSPort = 6
+				})
+				Context("when host TLS port is > 65535", func() {
+					BeforeEach(func() {
+						tcpMapping.HostTLSPort = 65546
+					})
+					It("throws an error", func() {
+						err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+						Expect(err).ToNot(BeNil())
+						Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+						Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
+					})
+				})
+				Context("when host port is zero", func() {
+					BeforeEach(func() {
+						tcpMapping.HostPort = 0
+					})
+					It("does not error", func() {
+						err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
 			})
 
 			It("blows up when a external port is zero", func() {


### PR DESCRIPTION
… route

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
