### PR TITLE
Fix v6 migration

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -149,8 +149,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 
 		JustBeforeEach(func() {
@@ -357,8 +357,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 		JustBeforeEach(func() {
 			err = client.DeleteTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2})
@@ -531,8 +531,8 @@ var _ = Describe("Client", func() {
 			data             []byte
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60)
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60)
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
 		})
 
 		Context("when the server returns a valid response", func() {
@@ -1118,7 +1118,7 @@ var _ = Describe("Client", func() {
 		)
 
 		BeforeEach(func() {
-			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60)
+			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60002, "", nil, 60, models.ModificationTag{})
 
 			data, _ := json.Marshal(tcpRoute1)
 			event = sse.Event{

--- a/cmd/routing-api/api_test.go
+++ b/cmd/routing-api/api_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Routes API", func() {
 			BeforeEach(func() {
 				routerGroupGuid = getRouterGroupGuid()
 
-				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 60)
+				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 60, models.ModificationTag{})
 				eventStream, err = client.SubscribeToTcpEvents()
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -71,7 +71,7 @@ var _ = Describe("Routes API", func() {
 				done := make(chan interface{})
 				go func() {
 					defer close(done)
-					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 75)
+					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 75, models.ModificationTag{})
 
 					routesToInsert := []models.TcpRouteMapping{route1}
 
@@ -119,7 +119,7 @@ var _ = Describe("Routes API", func() {
 			})
 
 			It("gets events for expired routes", func() {
-				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1)
+				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 1, models.ModificationTag{})
 
 				err := client.UpsertTcpRouteMappings([]models.TcpRouteMapping{routeExpire})
 				Expect(err).NotTo(HaveOccurred())
@@ -341,8 +341,8 @@ var _ = Describe("Routes API", func() {
 			Context("POST", func() {
 				It("allows to create given tcp route mappings", func() {
 					var err error
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 3)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 
 					tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -358,7 +358,7 @@ var _ = Describe("Routes API", func() {
 				Context("when tcp route mappings already exist", func() {
 					BeforeEach(func() {
 						var err error
-						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
+						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60001, "", nil, 60, models.ModificationTag{})
 
 						tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1}
 						err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -406,8 +406,8 @@ var _ = Describe("Routes API", func() {
 				})
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
 
@@ -432,8 +432,8 @@ var _ = Describe("Routes API", func() {
 				)
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60)
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60)
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err := client.UpsertTcpRouteMappings(tcpRouteMappings)
 

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 var _ = Describe("SqlDB", func() {
-
 	var (
 		sqlCfg *config.SqlDB
 		sqlDB  *db.SqlDB
@@ -605,7 +604,6 @@ var _ = Describe("SqlDB", func() {
 					Expect(rg.ReservablePorts).To(Equal(routerGroup.ReservablePorts))
 					Expect(rg.Type).To(Equal(routerGroup.Type))
 				})
-
 			})
 
 			It("Can remove ReservablePorts", func() {
@@ -644,7 +642,6 @@ var _ = Describe("SqlDB", func() {
 				})
 			})
 		})
-
 	}
 
 	DeleteRouterGroup := func() {
@@ -746,7 +743,7 @@ var _ = Describe("SqlDB", func() {
 
 			BeforeEach(func() {
 				routerGroupId = newUuid()
-				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
+				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, models.ModificationTag{})
 			})
 
 			AfterEach(func() {
@@ -779,7 +776,7 @@ var _ = Describe("SqlDB", func() {
 
 				It("refreshes the expiration time of the mapping", func() {
 					var dbTcpRoute models.TcpRouteMapping
-					var ttl = 9
+					ttl := 9
 					err = sqlDB.Client.Where("host_ip = ?", "127.0.0.1").First(&dbTcpRoute)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(dbTcpRoute).ToNot(BeNil())
@@ -802,7 +799,7 @@ var _ = Describe("SqlDB", func() {
 					)
 					BeforeEach(func() {
 						routerGroupId2 = newUuid()
-						tcpRoute2 = models.NewTcpRouteMapping(routerGroupId2, 3056, "127.0.0.1", 2990, 5)
+						tcpRoute2 = models.NewTcpRouteMapping(routerGroupId2, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, models.ModificationTag{})
 					})
 
 					AfterEach(func() {
@@ -888,7 +885,7 @@ var _ = Describe("SqlDB", func() {
 				BeforeEach(func() {
 					routerGroupId = newUuid()
 					modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
+					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, 5, modTag)
 					tcpRoute.ModificationTag = modTag
 					tcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
@@ -916,8 +913,7 @@ var _ = Describe("SqlDB", func() {
 
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-						expiredTcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, -9)
-						expiredTcpRoute.ModificationTag = modTag
+						expiredTcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "", nil, -9, modTag)
 						expiredTcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(expiredTcpRoute)
 						Expect(err).NotTo(HaveOccurred())
 						_, err = sqlDB.Client.Create(&expiredTcpRouteWithModel)
@@ -972,7 +968,7 @@ var _ = Describe("SqlDB", func() {
 				)
 
 				createTcpRouteWithIsoSeg := func(externalPort uint16, routerGroupID string, ttl int, isoSeg string) {
-					tcpRoute := models.NewTcpRouteMapping(routerGroupID, externalPort, "127.0.0.1", 2990, ttl)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupID, 3056, "127.0.0.1", 2990, 2991, "", nil, ttl, models.ModificationTag{})
 					tcpRoute.IsolationSegment = isoSeg
 					tcpRoute.ModificationTag = models.ModificationTag{Guid: "some-tag", Index: 10}
 					tcpRouteWithModel, err := models.NewTcpRouteMappingWithModel(tcpRoute)
@@ -1055,8 +1051,7 @@ var _ = Describe("SqlDB", func() {
 			BeforeEach(func() {
 				routerGroupId = newUuid()
 				modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 5)
-				tcpRoute.ModificationTag = modTag
+				tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3056, "127.0.0.1", 2990, 2991, "instanceId", nil, 5, modTag)
 				tcpRouteWithModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -1089,8 +1084,7 @@ var _ = Describe("SqlDB", func() {
 
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
-						tcpRoute2 := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 5)
-						tcpRoute2.ModificationTag = modTag
+						tcpRoute2 := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 5, modTag)
 						tcpRouteWithModel2, err = models.NewTcpRouteMappingWithModel(tcpRoute2)
 						Expect(err).ToNot(HaveOccurred())
 						_, err = sqlDB.Client.Create(&tcpRouteWithModel2)
@@ -1161,7 +1155,7 @@ var _ = Describe("SqlDB", func() {
 
 				It("refreshes the expiration time of the route", func() {
 					var dbRoute models.Route
-					var ttl = 9
+					ttl := 9
 					err = sqlDB.Client.Where("ip = ?", "127.0.0.1").First(&dbRoute)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(dbRoute).ToNot(BeNil())
@@ -1341,9 +1335,7 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				Context("when multiple routes exist", func() {
-					var (
-						routeWithModel2 models.Route
-					)
+					var routeWithModel2 models.Route
 					BeforeEach(func() {
 						modTag := models.ModificationTag{Guid: "some-tag", Index: 10}
 						route := models.NewRoute("post_here", 7001, "127.0.0.1", "my-guid", "https://rs.com", 5)
@@ -1412,12 +1404,10 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when a tcp route is updated", func() {
-				var (
-					tcpRoute models.TcpRouteMapping
-				)
+				var tcpRoute models.TcpRouteMapping
 
 				BeforeEach(func() {
-					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute = models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 				})
@@ -1430,7 +1420,11 @@ var _ = Describe("SqlDB", func() {
 						tcpRoute.ExternalPort,
 						tcpRoute.HostIP,
 						tcpRoute.HostPort,
+						tcpRoute.HostTLSPort,
+						tcpRoute.InstanceId,
+						tcpRoute.SniHostname,
 						*tcpRoute.TTL+1,
+						tcpRoute.ModificationTag,
 					)
 
 					err = sqlDB.SaveTcpRouteMapping(updatedTcpRoute)
@@ -1448,7 +1442,7 @@ var _ = Describe("SqlDB", func() {
 				It("should return an create watch event", func() {
 					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
 
-					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1462,7 +1456,7 @@ var _ = Describe("SqlDB", func() {
 
 			Context("when a route is deleted", func() {
 				It("should return an delete watch event", func() {
-					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 50)
+					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err := sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -1506,15 +1500,12 @@ var _ = Describe("SqlDB", func() {
 
 					Consistently(event).ShouldNot(Receive())
 					Eventually(event).Should(BeClosed())
-
 				})
 			})
 		})
 
 		Describe("WatchChanges with http events", func() {
-			var (
-				err error
-			)
+			var err error
 
 			It("does not return an error when canceled", func() {
 				_, errors, cancel := sqlDB.WatchChanges(db.HTTP_WATCH)
@@ -1524,9 +1515,7 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when a http route is updated", func() {
-				var (
-					httpRoute models.Route
-				)
+				var httpRoute models.Route
 
 				BeforeEach(func() {
 					httpRoute = models.NewRoute("post_here", 7001, "127.0.0.1", "my-guid", "https://rs.com", 5)
@@ -1605,7 +1594,6 @@ var _ = Describe("SqlDB", func() {
 
 					Consistently(event).ShouldNot(Receive())
 					Eventually(event).Should(BeClosed())
-
 				})
 			})
 		})
@@ -1663,14 +1651,13 @@ var _ = Describe("SqlDB", func() {
 
 					Eventually(fakeClient.DeleteCallCount).Should(Equal(4))
 				})
-
 			})
 
 			Context("tcp routes", func() {
 				var tcpRouteModel models.TcpRouteMapping
 
 				BeforeEach(func() {
-					tcpRoute := models.NewTcpRouteMapping("guid", 3555, "127.0.0.1", 7879, 2)
+					tcpRoute := models.NewTcpRouteMapping("guid", 3555, "127.0.0.1", 7879, 7880, "instanceId", nil, 2, models.ModificationTag{})
 					var err error
 					tcpRouteModel, err = models.NewTcpRouteMappingWithModel(tcpRoute)
 					Expect(err).ToNot(HaveOccurred())
@@ -1684,7 +1671,6 @@ var _ = Describe("SqlDB", func() {
 
 				Context("when db connection is successful", func() {
 					Context("when all routes have expired", func() {
-
 						It("should prune the expired routes and log the number of pruned routes", func() {
 							Eventually(func() []models.TcpRouteMapping {
 								var tcpRoutes []models.TcpRouteMapping
@@ -1709,7 +1695,7 @@ var _ = Describe("SqlDB", func() {
 						var tcpRoute models.TcpRouteMapping
 
 						BeforeEach(func() {
-							tcpRoute = models.NewTcpRouteMapping("guid", 3556, "127.0.0.1", 7879, 100)
+							tcpRoute = models.NewTcpRouteMapping("guid", 3556, "127.0.0.1", 7879, 7880, "instanceId", nil, 100, models.ModificationTag{})
 							err := sqlDB.SaveTcpRouteMapping(tcpRoute)
 							Expect(err).ToNot(HaveOccurred())
 
@@ -1800,7 +1786,6 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			Context("when db throws an error", func() {
-
 				BeforeEach(func() {
 					err := sqlDB.Client.Close()
 					Expect(err).ToNot(HaveOccurred())
@@ -1828,7 +1813,6 @@ var _ = Describe("SqlDB", func() {
 				expiryTime = time.UnixMilli(1652378100300)
 				queryTime = time.UnixMilli(1652378100200)
 				fc = fakeclock.NewFakeClock(queryTime)
-
 			})
 			Context("tcpRoutes", func() {
 				BeforeEach(func() {
@@ -1876,7 +1860,6 @@ var _ = Describe("SqlDB", func() {
 					Expect(len(httpRoutes)).To(Equal(0))
 				})
 			})
-
 		})
 	}
 	Describe("DB Connection Configuration", func() {
@@ -1885,9 +1868,7 @@ var _ = Describe("SqlDB", func() {
 	})
 
 	Describe("Test", func() {
-		var (
-			err error
-		)
+		var err error
 
 		BeforeEach(func() {
 			sqlCfg = databaseCfg

--- a/docs/02-api-docs.md
+++ b/docs/02-api-docs.md
@@ -317,17 +317,21 @@ curl -vvv -H "Authorization: bearer [uaa token]" http://api.system-domain.com/ro
 | `router_group_guid` | string          | GUID of the router group associated with this route.
 | `backend_port`      | integer         | Backend port. Must be greater than 0.
 | `backend_ip`        | string          | IP address of backend.
+| `backend_tls_port`  | integer         | Backend TLS port. If 0, backend TLS is disabled. If nil, backend TLS is not something the client knows about.
+| `instance_id`       | string          | Instance ID of the backend, used for TLS validation when backend TLS is enabled.
 | `port`              | integer         | External facing port for the TCP route.
 | `modification_tag`  | object     | See [Modification Tags](./03-modification-tags.md).
 | `ttl`               | integer         | Time to live, in seconds. The mapping of backend to route will be pruned after this time.
-| `isolation_segment` | string | Isolation segment for the route. |
+| `isolation_segment` | string          | Isolation segment for the route. |
 
 #### Example Response:
 ```json
 [{
   "router_group_guid": "xyz789",
-  "backend_port": 60000,
   "backend_ip": "10.1.1.12",
+  "backend_port": 60000,
+  "backend_tls_port": 60001,
+  "instance_id", "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "port": 5200,
   "modification_tag":  {
     "guid": "cbdhb4e3-141d-4259-b0ac-99140e8998l0",
@@ -357,6 +361,8 @@ As routes have a TTL, clients must register routes periodically to keep them act
 | `port`                 | integer         | yes       | External facing port for the TCP route.
 | `backend_ip`           | string          | yes       | IP address of backend
 | `backend_port`         | integer         | yes       | Backend port. Must be greater than 0.
+| `backend_tls_port`     | integer         | no        | Backend TLS port. If 0, indicates no TLS. If not provided, indicates a client that doesn't know about backend TLS port support. Otherwise must be greater than 0.
+| `instance_id`          | string          | no        | Instance ID of the backend container. Used to validate the TLS cert of a backend.
 | `ttl`                  | integer         | yes       | Time to live, in seconds. The mapping of backend to route will be pruned after this time. Must be greater than 0 seconds and less than the configured value for max_ttl (default 120 seconds).
 | `modification_tag`     | object          | no        | See [Modification Tags](03-modification-tags.md).
 | `isolation_segment`    | string          | no        | Name of the isolation segment for the route.
@@ -370,6 +376,8 @@ curl -vvv -H "Authorization: bearer [uaa token]" -X POST http://api.system-domai
   "port": 5200,
   "backend_ip": "10.1.1.12",
   "backend_port": 60000,
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "ttl": 120,
   "modification_tag":  {
     "guid": "cbdhb4e3-141d-4259-b0ac-99140e8998l0",
@@ -385,6 +393,8 @@ curl -k -vvv -H "Authorization: bearer $uaa_token" -X POST https://api.system-do
   "port": 1121,
   "backend_ip": "10.0.8.5",
   "backend_port": 8888,
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
   "backend_sni_hostname":"teststst.asd.com",
   "ttl": 120
 }]'
@@ -410,6 +420,8 @@ Delete TCP Routes
 | `port`              | integer         | yes       | External facing port for the TCP route.
 | `backend_ip`        | string          | yes       | IP address of backend
 | `backend_port`      | integer         | yes       | Backend port. Must be greater than 0.
+| `backend_tls_port`  | integer         | no        | Backend TLS port. If 0, indicates no TLS. If not provided, indicates a client that doesn't know about backend TLS port support. Otherwise must be greater than 0.
+| `instance_id`       | string          | no        | Instance ID of the backend container. Used to validate the TLS cert of a backend.
 
 #### Example Request
 ```bash
@@ -419,6 +431,8 @@ curl -vvv -H "Authorization: bearer [uaa token]" -X POST http://api.system-domai
   "port": 5200,
   "backend_ip": "10.1.1.12",
   "backend_port": 60000
+  "backend_tls_port": 60001,
+  "instance_id": "91860bfe-ecff-480d-8df4-0d1eb0295b04",
 }]'
 ```
 
@@ -451,11 +465,11 @@ curl -vvv -H "Authorization: bearer [uaa token]" http://api.system-domain.com/ro
 ```
 id: 0
 event: Upsert
-data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":1},"ttl":120}
+data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_tls_port":60001,"instance_id":"91860bfe-ecff-480d-8df4-0d1eb0295b04","backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":1},"ttl":120}
 
 id: 1
 event: Upsert
-data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":2},"ttl":120}
+data: {"router_group_guid":"xyz789","port":5200,"backend_port":60000,"backend_tls_port":60001,"instance_id":"91860bfe-ecff-480d-8df4-0d1eb0295b04","backend_ip":"10.1.1.12","modification_tag":{"guid":"abc123","index":2},"ttl":120}
 ```
 
 List HTTP Routes (Experimental)

--- a/event_source_test.go
+++ b/event_source_test.go
@@ -167,7 +167,7 @@ var _ = Describe("EventSource", func() {
 						rawEvent := sse.Event{
 							ID:    "1",
 							Name:  "Test",
-							Data:  []byte(`{"router_group_guid": "rguid1", "port":52000, "backend_port":60000,"backend_ip":"1.1.1.1","modification_tag":{"guid":"my-guid","index":5}}`),
+							Data:  []byte(`{"router_group_guid": "rguid1", "port":52000, "backend_port":60000,"backend_ip":"1.1.1.1","modification_tag":{"guid":"my-guid","index":5},"instance_id":"instance-id","backend_tls_port":60001}`),
 							Retry: 1,
 						}
 
@@ -175,8 +175,7 @@ var _ = Describe("EventSource", func() {
 							Guid:  "my-guid",
 							Index: 5,
 						}
-						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 5)
-						tcpMapping.ModificationTag = modTag
+						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60001, "instance-id", nil, 5, modTag)
 						tcpMapping.TTL = nil
 
 						expectedEvent := routing_api.TcpEvent{

--- a/handlers/validator.go
+++ b/handlers/validator.go
@@ -185,9 +185,15 @@ func validateTcpRouteMapping(tcpRouteMapping models.TcpRouteMapping, checkTTL bo
 		return &err
 	}
 
-	if tcpRouteMapping.HostPort <= 0 {
+	if tcpRouteMapping.HostPort <= 0 && tcpRouteMapping.HostTLSPort <= 0 {
 		err := routing_api.NewError(routing_api.TcpRouteMappingInvalidError,
 			"Each tcp mapping requires a positive backend port. RouteMapping=["+tcpRouteMapping.String()+"]")
+		return &err
+	}
+
+	if tcpRouteMapping.HostTLSPort > 65535 {
+		err := routing_api.NewError(routing_api.TcpRouteMappingInvalidError,
+			"Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535. RouteMapping=["+tcpRouteMapping.String()+"]")
 		return &err
 	}
 

--- a/migration/V5_sni_hostname_migration.go
+++ b/migration/V5_sni_hostname_migration.go
@@ -22,7 +22,7 @@ func (v *V5SniHostnameMigration) Run(sqlDB *db.SqlDB) error {
 	if err != nil {
 		return err
 	}
-	err = sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	_, err = sqlDB.Client.Model(&models.TcpRouteMapping{}).AddUniqueIndex("idx_tcp_route", "router_group_guid", "host_port", "host_ip", "external_port", "sni_hostname")
 	if err != nil {
 		return err
 	}

--- a/migration/V6_tls_tcp_route.go
+++ b/migration/V6_tls_tcp_route.go
@@ -1,0 +1,34 @@
+package migration
+
+import (
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+type V6TCPTLSRoutes struct{}
+
+var _ Migration = new(V6TCPTLSRoutes)
+
+func NewV6TCPTLSRoutes() *V6TCPTLSRoutes {
+	return &V6TCPTLSRoutes{}
+}
+
+func (v *V6TCPTLSRoutes) Version() int {
+	return 6
+}
+
+func (v *V6TCPTLSRoutes) Run(sqlDB *db.SqlDB) error {
+	_, err := sqlDB.Client.Model(&models.TcpRouteMapping{}).RemoveIndex("idx_tcp_route")
+	if err != nil {
+		return err
+	}
+	err = sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+	if err != nil {
+		return err
+	}
+	_, err = sqlDB.Client.Model(&models.TcpRouteMapping{}).AddUniqueIndex("idx_tcp_route", "router_group_guid", "host_port", "host_ip", "external_port", "sni_hostname", "host_tls_port")
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/migration/V6_tls_tcp_route_test.go
+++ b/migration/V6_tls_tcp_route_test.go
@@ -1,0 +1,160 @@
+package migration_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/migration"
+	v5 "code.cloudfoundry.org/routing-api/migration/v5"
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V6TCPTLSRoutes", func() {
+	var (
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
+	)
+
+	BeforeEach(func() {
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
+		Expect(err).NotTo(HaveOccurred())
+
+		sqlDB, err = db.NewSqlDB(sqlCfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := dbAllocator.Delete()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	runTests := func() {
+		Context("After migration", func() {
+			BeforeEach(func() {
+				v6Migration := migration.NewV6TCPTLSRoutes()
+				err := v6Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-1"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId1",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("allows adding the same TCP routes with different host TLS ports", func() {
+				sniHostname2 := "sniHostname2"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     444,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId2",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname2,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).NotTo(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(2))
+			})
+
+			It("denies adding the same TCP routes with same host TLS ports", func() {
+				sniHostname1 := "sniHostname1"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						InstanceId:      "instanceId2",
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).To(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+			})
+
+			It("denies adding the same TCP routes with different instance_ids", func() {
+				sniHostname1 := "sniHostname1"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId2",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).To(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+			})
+		})
+	}
+
+	Describe("Version", func() {
+		It("returns 6 for the version", func() {
+			v6Migration := migration.NewV6TCPTLSRoutes()
+			Expect(v6Migration.Version()).To(Equal(6))
+		})
+	})
+
+	Describe("Run", func() {
+		Context("when there are existing tables with the old tcp_route model", func() {
+			BeforeEach(func() {
+				err := sqlDB.Client.AutoMigrate(&v5.RouterGroupDB{}, &v5.TcpRouteMapping{}, &v5.Route{})
+				Expect(err).ToNot(HaveOccurred())
+				v5Migration := migration.NewV5SniHostnameMigration()
+				err = v5Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+
+		Context("when the tables are newly created (by V0 init migration)", func() {
+			BeforeEach(func() {
+				v0Migration := migration.NewV0InitMigration()
+				err := v0Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+	})
+})

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -82,6 +82,9 @@ func InitializeMigrations() []Migration {
 	migration = NewV5SniHostnameMigration()
 	migrations = append(migrations, migration)
 
+	migration = NewV6TCPTLSRoutes()
+	migrations = append(migrations, migration)
+
 	return migrations
 }
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -41,13 +41,14 @@ var _ = Describe("Migration", func() {
 				done := make(chan struct{})
 				defer close(done)
 				migrations := migration.InitializeMigrations()
-				Expect(migrations).To(HaveLen(5))
+				Expect(migrations).To(HaveLen(6))
 
 				Expect(migrations[0]).To(BeAssignableToTypeOf(new(migration.V0InitMigration)))
 				Expect(migrations[1]).To(BeAssignableToTypeOf(new(migration.V2UpdateRgMigration)))
 				Expect(migrations[2]).To(BeAssignableToTypeOf(new(migration.V3UpdateTcpRouteMigration)))
 				Expect(migrations[3]).To(BeAssignableToTypeOf(new(migration.V4AddRgUniqIdxTCPRoute)))
 				Expect(migrations[4]).To(BeAssignableToTypeOf(new(migration.V5SniHostnameMigration)))
+				Expect(migrations[5]).To(BeAssignableToTypeOf(new(migration.V6TCPTLSRoutes)))
 			})
 		})
 

--- a/migration/v5/models.go
+++ b/migration/v5/models.go
@@ -1,0 +1,75 @@
+package v5
+
+import (
+	"time"
+)
+
+type Model struct {
+	Guid      string    `gorm:"primary_key" json:"-"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
+}
+
+type ModificationTag struct {
+	Guid  string `gorm:"column:modification_guid" json:"guid"`
+	Index uint32 `gorm:"column:modification_index" json:"index"`
+}
+
+type TcpRouteMapping struct {
+	Model
+	ExpiresAt time.Time `json:"-"`
+	TcpMappingEntity
+}
+
+func (TcpRouteMapping) TableName() string {
+	return "tcp_routes"
+}
+
+type TcpMappingEntity struct {
+	RouterGroupGuid  string  `gorm:"not null; unique_index:idx_tcp_route" json:"router_group_guid"`
+	HostPort         uint16  `gorm:"not null; unique_index:idx_tcp_route; type:int" json:"backend_port"`
+	HostIP           string  `gorm:"not null; unique_index:idx_tcp_route" json:"backend_ip"`
+	SniHostname      *string `gorm:"default:null; unique_index:idx_tcp_route" json:"backend_sni_hostname,omitempty"`
+	ExternalPort     uint16  `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
+	ModificationTag  `json:"modification_tag"`
+	TTL              *int   `json:"ttl,omitempty"`
+	IsolationSegment string `json:"isolation_segment"`
+}
+
+type Route struct {
+	Model
+	ExpiresAt time.Time `json:"-"`
+	RouteEntity
+}
+
+type RouteEntity struct {
+	Route           string `gorm:"not null; unique_index:idx_route" json:"route"`
+	Port            uint16 `gorm:"not null; unique_index:idx_route" json:"port"`
+	IP              string `gorm:"not null; unique_index:idx_route" json:"ip"`
+	TTL             *int   `json:"ttl"`
+	LogGuid         string `json:"log_guid"`
+	RouteServiceUrl string `gorm:"not null; unique_index:idx_route" json:"route_service_url,omitempty"`
+	ModificationTag `json:"modification_tag"`
+}
+
+type RouterGroupDB struct {
+	Model
+	Name            string
+	Type            string
+	ReservablePorts string
+}
+
+func (RouterGroupDB) TableName() string {
+	return "router_groups"
+}
+
+type RouterGroup struct {
+	Model
+	Guid            string          `json:"guid"`
+	Name            string          `json:"name"`
+	Type            RouterGroupType `json:"type"`
+	ReservablePorts ReservablePorts `json:"reservable_ports" yaml:"reservable_ports"`
+}
+
+type RouterGroupType string
+type ReservablePorts string

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -426,8 +426,7 @@ var _ = Describe("Models", func() {
 		BeforeEach(func() {
 			tag, err := NewModificationTag()
 			Expect(err).ToNot(HaveOccurred())
-			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 66)
-			route.ModificationTag = tag
+			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag)
 		})
 
 		Describe("SetDefaults", func() {

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -14,11 +14,16 @@ type TcpRouteMapping struct {
 }
 
 type TcpMappingEntity struct {
-	RouterGroupGuid  string  `gorm:"not null; unique_index:idx_tcp_route" json:"router_group_guid"`
-	HostPort         uint16  `gorm:"not null; unique_index:idx_tcp_route; type:int" json:"backend_port"`
-	HostIP           string  `gorm:"not null; unique_index:idx_tcp_route" json:"backend_ip"`
-	SniHostname      *string `gorm:"default:null; unique_index:idx_tcp_route" json:"backend_sni_hostname,omitempty"`
-	ExternalPort     uint16  `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
+	RouterGroupGuid string  `gorm:"not null; unique_index:idx_tcp_route" json:"router_group_guid"`
+	HostPort        uint16  `gorm:"not null; unique_index:idx_tcp_route; type:int" json:"backend_port"`
+	HostTLSPort     int     `gorm:"default:null; unique_index:idx_tcp_route; type:int" json:"backend_tls_port"`
+	HostIP          string  `gorm:"not null; unique_index:idx_tcp_route" json:"backend_ip"`
+	SniHostname     *string `gorm:"default:null; unique_index:idx_tcp_route" json:"backend_sni_hostname,omitempty"`
+	// We don't add uniqueness on InstanceId so that if a route is attempted to be created with the same detals but
+	// different InstanceId, we fail uniqueness and prevent stale/duplicate routes. If this fails a route, the
+	// TTL on the old record should expire + allow the new route to be created eventually.
+	InstanceId       string `gorm:"not null;" json:"instance_id"`
+	ExternalPort     uint16 `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
 	ModificationTag  `json:"modification_tag"`
 	TTL              *int   `json:"ttl,omitempty"`
 	IsolationSegment string `json:"isolation_segment"`
@@ -42,47 +47,30 @@ func NewTcpRouteMappingWithModel(tcpMapping TcpRouteMapping) (TcpRouteMapping, e
 	}, nil
 }
 
-func NewTcpRouteMapping(routerGroupGuid string, externalPort uint16, hostIP string, hostPort uint16, ttl int) TcpRouteMapping {
-	return NewSniTcpRouteMapping(routerGroupGuid, externalPort, nil, hostIP, hostPort, ttl)
-}
-
-func NewSniTcpRouteMapping(routerGroupGuid string, externalPort uint16, sniHostname *string, hostIP string, hostPort uint16, ttl int) TcpRouteMapping {
-	mapping := TcpMappingEntity{
-		RouterGroupGuid: routerGroupGuid,
-		ExternalPort:    externalPort,
-		SniHostname:     sniHostname,
-		HostPort:        hostPort,
-		HostIP:          hostIP,
-		TTL:             &ttl,
-	}
-	return TcpRouteMapping{
-		TcpMappingEntity: mapping,
-	}
-}
-
-func NewTcpRouteMappingWithModificationTag(
+func NewTcpRouteMapping(
 	routerGroupGuid string,
 	externalPort uint16,
 	hostIP string,
 	hostPort uint16,
-	ttl int,
-	modTag ModificationTag,
-) TcpRouteMapping {
-	return NewSniTcpRouteMappingWithModificationTag(routerGroupGuid, externalPort, nil, hostIP, hostPort, ttl, modTag)
-}
-
-func NewSniTcpRouteMappingWithModificationTag(
-	routerGroupGuid string,
-	externalPort uint16,
+	hostTlsPort int,
+	instanceId string,
 	sniHostname *string,
-	hostIP string,
-	hostPort uint16,
 	ttl int,
 	modTag ModificationTag,
 ) TcpRouteMapping {
-	mapping := NewSniTcpRouteMapping(routerGroupGuid, externalPort, sniHostname, hostIP, hostPort, ttl)
-	mapping.ModificationTag = modTag
-
+	mapping := TcpRouteMapping{
+		TcpMappingEntity: TcpMappingEntity{
+			RouterGroupGuid: routerGroupGuid,
+			ExternalPort:    externalPort,
+			SniHostname:     sniHostname,
+			InstanceId:      instanceId,
+			HostPort:        hostPort,
+			HostTLSPort:     hostTlsPort,
+			HostIP:          hostIP,
+			TTL:             &ttl,
+			ModificationTag: modTag,
+		},
+	}
 	return mapping
 }
 
@@ -91,13 +79,31 @@ func (m TcpRouteMapping) String() string {
 }
 
 func (m TcpRouteMapping) Matches(other TcpRouteMapping) bool {
-	return m.RouterGroupGuid == other.RouterGroupGuid &&
-		m.ExternalPort == other.ExternalPort &&
-		m.HostIP == other.HostIP &&
-		m.HostPort == other.HostPort &&
-		*m.TTL == *other.TTL &&
-		((m.SniHostname == other.SniHostname) ||
-			m.SniHostname != nil && *m.SniHostname == *other.SniHostname)
+	sameRouterGroupGuid := m.RouterGroupGuid == other.RouterGroupGuid
+	sameExternalPort := m.ExternalPort == other.ExternalPort
+	sameHostIP := m.HostIP == other.HostIP
+	sameHostPort := m.HostPort == other.HostPort
+	sameInstanceId := m.InstanceId == other.InstanceId
+	sameHostTLSPort := m.HostTLSPort == other.HostTLSPort
+
+	nilTTL := m.TTL == nil && other.TTL == nil
+	sameTTLPointer := m.TTL == other.TTL
+	sameTTLValue := m.TTL != nil && other.TTL != nil && *m.TTL == *other.TTL
+	sameTTL := nilTTL || sameTTLPointer || sameTTLValue
+
+	nilSniHostname := m.SniHostname == nil && other.SniHostname == nil
+	sameSniHostnamePointer := m.SniHostname == other.SniHostname
+	sameSniHostnameValue := m.SniHostname != nil && other.SniHostname != nil && *m.SniHostname == *other.SniHostname
+	sameSniHostname := nilSniHostname || sameSniHostnamePointer || sameSniHostnameValue
+
+	return sameRouterGroupGuid &&
+		sameExternalPort &&
+		sameHostIP &&
+		sameHostPort &&
+		sameInstanceId &&
+		sameTTL &&
+		sameHostTLSPort &&
+		sameSniHostname
 }
 
 func (t *TcpRouteMapping) SetDefaults(maxTTL int) {

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -22,7 +22,7 @@ type TcpMappingEntity struct {
 	// We don't add uniqueness on InstanceId so that if a route is attempted to be created with the same detals but
 	// different InstanceId, we fail uniqueness and prevent stale/duplicate routes. If this fails a route, the
 	// TTL on the old record should expire + allow the new route to be created eventually.
-	InstanceId       string `gorm:"not null;" json:"instance_id"`
+	InstanceId       string `gorm:"default:null;" json:"instance_id"`
 	ExternalPort     uint16 `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
 	ModificationTag  `json:"modification_tag"`
 	TTL              *int   `json:"ttl,omitempty"`


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------

    Fixes issue with v6 migration and postgres

    Originally in v0.301.0 the v6 migration would fail to migrate on
    postgres databases due to existing records without an `instance_id`
    column, and adding the column with a not-null constraint. There was
    no default value to give the columns so it failed.

    On mysql, the migration succeeded, and since mysql is the default
    database used in cf-deployment when we test with uptimer, we never
    noticed this issue.

    Additionally the unit tests for the migration didn't have existing data,
    just existing tables.


Backward Compatibility
---------------
Breaking Change? no