### PR TITLE
Update routing-api migration logic to match BBS

### DIFF
--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -163,8 +163,8 @@ func main() {
 	}
 
 	members := grouper.Members{
-		grouper.Member{Name: "migration", Runner: migrationProcess},
 		grouper.Member{Name: "lock-acquirer", Runner: lockAcquirer},
+		grouper.Member{Name: "migration", Runner: migrationProcess},
 		grouper.Member{Name: "seed-router-groups", Runner: routerGroupSeeder},
 	}
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Previously, the migration logic would guard against multiple migrations running simultaneously by looking to see if the target version had been updated already, and did not use locket to ensure a process lock prior to executing migrations.

This caused issues. First, failed migrations would not be re-run until a new migration was defined + released, or the migration_data table was reset manually. Second, it means during upgrades, a non-primary routing-api would be able to modify the schema, while the primary routing-api node had not yet been updated with corresponding code changes. Lastly, it means that failed migrations would not cause BOSH deploy failures, as monit would restart routing-api after a migration failure, but then routing-api wouldn't attempt to migrate again, and the deployment would go green.

Now, routing-api behaves like BBS. It acquires the locket lock prior to migrating databases, and rather than checking target version against desired version before exiting migration logic, it checks current version against desired version, allowing it to re-attempt migrations, either succeeding, or consistently failing and stopping a BOSH deployment.



Backward Compatibility
---------------
Breaking Change? no