### PR TITLE
Add migration to force removing not-null from existing tables because…

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	Exec(query string, args ...interface{}) int64
 	Rows(tableName string) (*sql.Rows, error)
 	DropColumn(column string) error
+	Dialect() gorm.Dialect
 }
 
 type gormClient struct {
@@ -46,6 +47,10 @@ func (c *gormClient) AddUniqueIndex(indexName string, columns ...string) (Client
 	var newClient gormClient
 	newClient.db = c.db.AddUniqueIndex(indexName, columns...)
 	return &newClient, newClient.db.Error
+}
+
+func (c *gormClient) Dialect() gorm.Dialect {
+	return c.db.Dialect()
 }
 
 func (c *gormClient) RemoveIndex(indexName string) (Client, error) {

--- a/db/fakes/fake_client.go
+++ b/db/fakes/fake_client.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"code.cloudfoundry.org/routing-api/db"
+	"github.com/jinzhu/gorm"
 )
 
 type FakeClient struct {
@@ -90,6 +91,16 @@ type FakeClient struct {
 	deleteReturnsOnCall map[int]struct {
 		result1 int64
 		result2 error
+	}
+	DialectStub        func() gorm.Dialect
+	dialectMutex       sync.RWMutex
+	dialectArgsForCall []struct {
+	}
+	dialectReturns struct {
+		result1 gorm.Dialect
+	}
+	dialectReturnsOnCall map[int]struct {
+		result1 gorm.Dialect
 	}
 	DropColumnStub        func(string) error
 	dropColumnMutex       sync.RWMutex
@@ -245,15 +256,16 @@ func (fake *FakeClient) AddUniqueIndex(arg1 string, arg2 ...string) (db.Client, 
 		arg1 string
 		arg2 []string
 	}{arg1, arg2})
+	stub := fake.AddUniqueIndexStub
+	fakeReturns := fake.addUniqueIndexReturns
 	fake.recordInvocation("AddUniqueIndex", []interface{}{arg1, arg2})
 	fake.addUniqueIndexMutex.Unlock()
-	if fake.AddUniqueIndexStub != nil {
-		return fake.AddUniqueIndexStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.addUniqueIndexReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -308,15 +320,16 @@ func (fake *FakeClient) AutoMigrate(arg1 ...interface{}) error {
 	fake.autoMigrateArgsForCall = append(fake.autoMigrateArgsForCall, struct {
 		arg1 []interface{}
 	}{arg1})
+	stub := fake.AutoMigrateStub
+	fakeReturns := fake.autoMigrateReturns
 	fake.recordInvocation("AutoMigrate", []interface{}{arg1})
 	fake.autoMigrateMutex.Unlock()
-	if fake.AutoMigrateStub != nil {
-		return fake.AutoMigrateStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.autoMigrateReturns
 	return fakeReturns.result1
 }
 
@@ -367,15 +380,16 @@ func (fake *FakeClient) Begin() db.Client {
 	ret, specificReturn := fake.beginReturnsOnCall[len(fake.beginArgsForCall)]
 	fake.beginArgsForCall = append(fake.beginArgsForCall, struct {
 	}{})
+	stub := fake.BeginStub
+	fakeReturns := fake.beginReturns
 	fake.recordInvocation("Begin", []interface{}{})
 	fake.beginMutex.Unlock()
-	if fake.BeginStub != nil {
-		return fake.BeginStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.beginReturns
 	return fakeReturns.result1
 }
 
@@ -419,15 +433,16 @@ func (fake *FakeClient) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -471,15 +486,16 @@ func (fake *FakeClient) Commit() error {
 	ret, specificReturn := fake.commitReturnsOnCall[len(fake.commitArgsForCall)]
 	fake.commitArgsForCall = append(fake.commitArgsForCall, struct {
 	}{})
+	stub := fake.CommitStub
+	fakeReturns := fake.commitReturns
 	fake.recordInvocation("Commit", []interface{}{})
 	fake.commitMutex.Unlock()
-	if fake.CommitStub != nil {
-		return fake.CommitStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.commitReturns
 	return fakeReturns.result1
 }
 
@@ -524,15 +540,16 @@ func (fake *FakeClient) Create(arg1 interface{}) (int64, error) {
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -588,15 +605,16 @@ func (fake *FakeClient) Delete(arg1 interface{}, arg2 ...interface{}) (int64, er
 		arg1 interface{}
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -645,21 +663,75 @@ func (fake *FakeClient) DeleteReturnsOnCall(i int, result1 int64, result2 error)
 	}{result1, result2}
 }
 
+func (fake *FakeClient) Dialect() gorm.Dialect {
+	fake.dialectMutex.Lock()
+	ret, specificReturn := fake.dialectReturnsOnCall[len(fake.dialectArgsForCall)]
+	fake.dialectArgsForCall = append(fake.dialectArgsForCall, struct {
+	}{})
+	stub := fake.DialectStub
+	fakeReturns := fake.dialectReturns
+	fake.recordInvocation("Dialect", []interface{}{})
+	fake.dialectMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DialectCallCount() int {
+	fake.dialectMutex.RLock()
+	defer fake.dialectMutex.RUnlock()
+	return len(fake.dialectArgsForCall)
+}
+
+func (fake *FakeClient) DialectCalls(stub func() gorm.Dialect) {
+	fake.dialectMutex.Lock()
+	defer fake.dialectMutex.Unlock()
+	fake.DialectStub = stub
+}
+
+func (fake *FakeClient) DialectReturns(result1 gorm.Dialect) {
+	fake.dialectMutex.Lock()
+	defer fake.dialectMutex.Unlock()
+	fake.DialectStub = nil
+	fake.dialectReturns = struct {
+		result1 gorm.Dialect
+	}{result1}
+}
+
+func (fake *FakeClient) DialectReturnsOnCall(i int, result1 gorm.Dialect) {
+	fake.dialectMutex.Lock()
+	defer fake.dialectMutex.Unlock()
+	fake.DialectStub = nil
+	if fake.dialectReturnsOnCall == nil {
+		fake.dialectReturnsOnCall = make(map[int]struct {
+			result1 gorm.Dialect
+		})
+	}
+	fake.dialectReturnsOnCall[i] = struct {
+		result1 gorm.Dialect
+	}{result1}
+}
+
 func (fake *FakeClient) DropColumn(arg1 string) error {
 	fake.dropColumnMutex.Lock()
 	ret, specificReturn := fake.dropColumnReturnsOnCall[len(fake.dropColumnArgsForCall)]
 	fake.dropColumnArgsForCall = append(fake.dropColumnArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DropColumnStub
+	fakeReturns := fake.dropColumnReturns
 	fake.recordInvocation("DropColumn", []interface{}{arg1})
 	fake.dropColumnMutex.Unlock()
-	if fake.DropColumnStub != nil {
-		return fake.DropColumnStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.dropColumnReturns
 	return fakeReturns.result1
 }
 
@@ -712,15 +784,16 @@ func (fake *FakeClient) Exec(arg1 string, arg2 ...interface{}) int64 {
 		arg1 string
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.ExecStub
+	fakeReturns := fake.execReturns
 	fake.recordInvocation("Exec", []interface{}{arg1, arg2})
 	fake.execMutex.Unlock()
-	if fake.ExecStub != nil {
-		return fake.ExecStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.execReturns
 	return fakeReturns.result1
 }
 
@@ -773,15 +846,16 @@ func (fake *FakeClient) Find(arg1 interface{}, arg2 ...interface{}) error {
 		arg1 interface{}
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.FindStub
+	fakeReturns := fake.findReturns
 	fake.recordInvocation("Find", []interface{}{arg1, arg2})
 	fake.findMutex.Unlock()
-	if fake.FindStub != nil {
-		return fake.FindStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.findReturns
 	return fakeReturns.result1
 }
 
@@ -834,15 +908,16 @@ func (fake *FakeClient) First(arg1 interface{}, arg2 ...interface{}) error {
 		arg1 interface{}
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.FirstStub
+	fakeReturns := fake.firstReturns
 	fake.recordInvocation("First", []interface{}{arg1, arg2})
 	fake.firstMutex.Unlock()
-	if fake.FirstStub != nil {
-		return fake.FirstStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.firstReturns
 	return fakeReturns.result1
 }
 
@@ -894,15 +969,16 @@ func (fake *FakeClient) HasTable(arg1 interface{}) bool {
 	fake.hasTableArgsForCall = append(fake.hasTableArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.HasTableStub
+	fakeReturns := fake.hasTableReturns
 	fake.recordInvocation("HasTable", []interface{}{arg1})
 	fake.hasTableMutex.Unlock()
-	if fake.HasTableStub != nil {
-		return fake.HasTableStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.hasTableReturns
 	return fakeReturns.result1
 }
 
@@ -954,15 +1030,16 @@ func (fake *FakeClient) Model(arg1 interface{}) db.Client {
 	fake.modelArgsForCall = append(fake.modelArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.ModelStub
+	fakeReturns := fake.modelReturns
 	fake.recordInvocation("Model", []interface{}{arg1})
 	fake.modelMutex.Unlock()
-	if fake.ModelStub != nil {
-		return fake.ModelStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.modelReturns
 	return fakeReturns.result1
 }
 
@@ -1014,15 +1091,16 @@ func (fake *FakeClient) RemoveIndex(arg1 string) (db.Client, error) {
 	fake.removeIndexArgsForCall = append(fake.removeIndexArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveIndexStub
+	fakeReturns := fake.removeIndexReturns
 	fake.recordInvocation("RemoveIndex", []interface{}{arg1})
 	fake.removeIndexMutex.Unlock()
-	if fake.RemoveIndexStub != nil {
-		return fake.RemoveIndexStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.removeIndexReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1076,15 +1154,16 @@ func (fake *FakeClient) Rollback() error {
 	ret, specificReturn := fake.rollbackReturnsOnCall[len(fake.rollbackArgsForCall)]
 	fake.rollbackArgsForCall = append(fake.rollbackArgsForCall, struct {
 	}{})
+	stub := fake.RollbackStub
+	fakeReturns := fake.rollbackReturns
 	fake.recordInvocation("Rollback", []interface{}{})
 	fake.rollbackMutex.Unlock()
-	if fake.RollbackStub != nil {
-		return fake.RollbackStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rollbackReturns
 	return fakeReturns.result1
 }
 
@@ -1129,15 +1208,16 @@ func (fake *FakeClient) Rows(arg1 string) (*sql.Rows, error) {
 	fake.rowsArgsForCall = append(fake.rowsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RowsStub
+	fakeReturns := fake.rowsReturns
 	fake.recordInvocation("Rows", []interface{}{arg1})
 	fake.rowsMutex.Unlock()
-	if fake.RowsStub != nil {
-		return fake.RowsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.rowsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1192,15 +1272,16 @@ func (fake *FakeClient) Save(arg1 interface{}) (int64, error) {
 	fake.saveArgsForCall = append(fake.saveArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.SaveStub
+	fakeReturns := fake.saveReturns
 	fake.recordInvocation("Save", []interface{}{arg1})
 	fake.saveMutex.Unlock()
-	if fake.SaveStub != nil {
-		return fake.SaveStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.saveReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1255,15 +1336,16 @@ func (fake *FakeClient) Update(arg1 ...interface{}) (int64, error) {
 	fake.updateArgsForCall = append(fake.updateArgsForCall, struct {
 		arg1 []interface{}
 	}{arg1})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1...)
+	if stub != nil {
+		return stub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1319,15 +1401,16 @@ func (fake *FakeClient) Where(arg1 interface{}, arg2 ...interface{}) db.Client {
 		arg1 interface{}
 		arg2 []interface{}
 	}{arg1, arg2})
+	stub := fake.WhereStub
+	fakeReturns := fake.whereReturns
 	fake.recordInvocation("Where", []interface{}{arg1, arg2})
 	fake.whereMutex.Unlock()
-	if fake.WhereStub != nil {
-		return fake.WhereStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.whereReturns
 	return fakeReturns.result1
 }
 
@@ -1390,6 +1473,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.dialectMutex.RLock()
+	defer fake.dialectMutex.RUnlock()
 	fake.dropColumnMutex.RLock()
 	defer fake.dropColumnMutex.RUnlock()
 	fake.execMutex.RLock()

--- a/db/fakes/fake_db.go
+++ b/db/fakes/fake_db.go
@@ -195,9 +195,10 @@ func (fake *FakeDB) CancelWatches() {
 	fake.cancelWatchesMutex.Lock()
 	fake.cancelWatchesArgsForCall = append(fake.cancelWatchesArgsForCall, struct {
 	}{})
+	stub := fake.CancelWatchesStub
 	fake.recordInvocation("CancelWatches", []interface{}{})
 	fake.cancelWatchesMutex.Unlock()
-	if fake.CancelWatchesStub != nil {
+	if stub != nil {
 		fake.CancelWatchesStub()
 	}
 }
@@ -220,15 +221,16 @@ func (fake *FakeDB) DeleteRoute(arg1 models.Route) error {
 	fake.deleteRouteArgsForCall = append(fake.deleteRouteArgsForCall, struct {
 		arg1 models.Route
 	}{arg1})
+	stub := fake.DeleteRouteStub
+	fakeReturns := fake.deleteRouteReturns
 	fake.recordInvocation("DeleteRoute", []interface{}{arg1})
 	fake.deleteRouteMutex.Unlock()
-	if fake.DeleteRouteStub != nil {
-		return fake.DeleteRouteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteRouteReturns
 	return fakeReturns.result1
 }
 
@@ -280,15 +282,16 @@ func (fake *FakeDB) DeleteRouterGroup(arg1 string) error {
 	fake.deleteRouterGroupArgsForCall = append(fake.deleteRouterGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeleteRouterGroupStub
+	fakeReturns := fake.deleteRouterGroupReturns
 	fake.recordInvocation("DeleteRouterGroup", []interface{}{arg1})
 	fake.deleteRouterGroupMutex.Unlock()
-	if fake.DeleteRouterGroupStub != nil {
-		return fake.DeleteRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteRouterGroupReturns
 	return fakeReturns.result1
 }
 
@@ -340,15 +343,16 @@ func (fake *FakeDB) DeleteTcpRouteMapping(arg1 models.TcpRouteMapping) error {
 	fake.deleteTcpRouteMappingArgsForCall = append(fake.deleteTcpRouteMappingArgsForCall, struct {
 		arg1 models.TcpRouteMapping
 	}{arg1})
+	stub := fake.DeleteTcpRouteMappingStub
+	fakeReturns := fake.deleteTcpRouteMappingReturns
 	fake.recordInvocation("DeleteTcpRouteMapping", []interface{}{arg1})
 	fake.deleteTcpRouteMappingMutex.Unlock()
-	if fake.DeleteTcpRouteMappingStub != nil {
-		return fake.DeleteTcpRouteMappingStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteTcpRouteMappingReturns
 	return fakeReturns.result1
 }
 
@@ -398,9 +402,10 @@ func (fake *FakeDB) LockRouterGroupReads() {
 	fake.lockRouterGroupReadsMutex.Lock()
 	fake.lockRouterGroupReadsArgsForCall = append(fake.lockRouterGroupReadsArgsForCall, struct {
 	}{})
+	stub := fake.LockRouterGroupReadsStub
 	fake.recordInvocation("LockRouterGroupReads", []interface{}{})
 	fake.lockRouterGroupReadsMutex.Unlock()
-	if fake.LockRouterGroupReadsStub != nil {
+	if stub != nil {
 		fake.LockRouterGroupReadsStub()
 	}
 }
@@ -421,9 +426,10 @@ func (fake *FakeDB) LockRouterGroupWrites() {
 	fake.lockRouterGroupWritesMutex.Lock()
 	fake.lockRouterGroupWritesArgsForCall = append(fake.lockRouterGroupWritesArgsForCall, struct {
 	}{})
+	stub := fake.LockRouterGroupWritesStub
 	fake.recordInvocation("LockRouterGroupWrites", []interface{}{})
 	fake.lockRouterGroupWritesMutex.Unlock()
-	if fake.LockRouterGroupWritesStub != nil {
+	if stub != nil {
 		fake.LockRouterGroupWritesStub()
 	}
 }
@@ -452,15 +458,16 @@ func (fake *FakeDB) ReadFilteredTcpRouteMappings(arg1 string, arg2 []string) ([]
 		arg1 string
 		arg2 []string
 	}{arg1, arg2Copy})
+	stub := fake.ReadFilteredTcpRouteMappingsStub
+	fakeReturns := fake.readFilteredTcpRouteMappingsReturns
 	fake.recordInvocation("ReadFilteredTcpRouteMappings", []interface{}{arg1, arg2Copy})
 	fake.readFilteredTcpRouteMappingsMutex.Unlock()
-	if fake.ReadFilteredTcpRouteMappingsStub != nil {
-		return fake.ReadFilteredTcpRouteMappingsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readFilteredTcpRouteMappingsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -515,15 +522,16 @@ func (fake *FakeDB) ReadRouterGroup(arg1 string) (models.RouterGroup, error) {
 	fake.readRouterGroupArgsForCall = append(fake.readRouterGroupArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ReadRouterGroupStub
+	fakeReturns := fake.readRouterGroupReturns
 	fake.recordInvocation("ReadRouterGroup", []interface{}{arg1})
 	fake.readRouterGroupMutex.Unlock()
-	if fake.ReadRouterGroupStub != nil {
-		return fake.ReadRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readRouterGroupReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -578,15 +586,16 @@ func (fake *FakeDB) ReadRouterGroupByName(arg1 string) (models.RouterGroup, erro
 	fake.readRouterGroupByNameArgsForCall = append(fake.readRouterGroupByNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ReadRouterGroupByNameStub
+	fakeReturns := fake.readRouterGroupByNameReturns
 	fake.recordInvocation("ReadRouterGroupByName", []interface{}{arg1})
 	fake.readRouterGroupByNameMutex.Unlock()
-	if fake.ReadRouterGroupByNameStub != nil {
-		return fake.ReadRouterGroupByNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readRouterGroupByNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -640,15 +649,16 @@ func (fake *FakeDB) ReadRouterGroups() (models.RouterGroups, error) {
 	ret, specificReturn := fake.readRouterGroupsReturnsOnCall[len(fake.readRouterGroupsArgsForCall)]
 	fake.readRouterGroupsArgsForCall = append(fake.readRouterGroupsArgsForCall, struct {
 	}{})
+	stub := fake.ReadRouterGroupsStub
+	fakeReturns := fake.readRouterGroupsReturns
 	fake.recordInvocation("ReadRouterGroups", []interface{}{})
 	fake.readRouterGroupsMutex.Unlock()
-	if fake.ReadRouterGroupsStub != nil {
-		return fake.ReadRouterGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readRouterGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -695,15 +705,16 @@ func (fake *FakeDB) ReadRoutes() ([]models.Route, error) {
 	ret, specificReturn := fake.readRoutesReturnsOnCall[len(fake.readRoutesArgsForCall)]
 	fake.readRoutesArgsForCall = append(fake.readRoutesArgsForCall, struct {
 	}{})
+	stub := fake.ReadRoutesStub
+	fakeReturns := fake.readRoutesReturns
 	fake.recordInvocation("ReadRoutes", []interface{}{})
 	fake.readRoutesMutex.Unlock()
-	if fake.ReadRoutesStub != nil {
-		return fake.ReadRoutesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readRoutesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -750,15 +761,16 @@ func (fake *FakeDB) ReadTcpRouteMappings() ([]models.TcpRouteMapping, error) {
 	ret, specificReturn := fake.readTcpRouteMappingsReturnsOnCall[len(fake.readTcpRouteMappingsArgsForCall)]
 	fake.readTcpRouteMappingsArgsForCall = append(fake.readTcpRouteMappingsArgsForCall, struct {
 	}{})
+	stub := fake.ReadTcpRouteMappingsStub
+	fakeReturns := fake.readTcpRouteMappingsReturns
 	fake.recordInvocation("ReadTcpRouteMappings", []interface{}{})
 	fake.readTcpRouteMappingsMutex.Unlock()
-	if fake.ReadTcpRouteMappingsStub != nil {
-		return fake.ReadTcpRouteMappingsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.readTcpRouteMappingsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -806,15 +818,16 @@ func (fake *FakeDB) SaveRoute(arg1 models.Route) error {
 	fake.saveRouteArgsForCall = append(fake.saveRouteArgsForCall, struct {
 		arg1 models.Route
 	}{arg1})
+	stub := fake.SaveRouteStub
+	fakeReturns := fake.saveRouteReturns
 	fake.recordInvocation("SaveRoute", []interface{}{arg1})
 	fake.saveRouteMutex.Unlock()
-	if fake.SaveRouteStub != nil {
-		return fake.SaveRouteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveRouteReturns
 	return fakeReturns.result1
 }
 
@@ -866,15 +879,16 @@ func (fake *FakeDB) SaveRouterGroup(arg1 models.RouterGroup) error {
 	fake.saveRouterGroupArgsForCall = append(fake.saveRouterGroupArgsForCall, struct {
 		arg1 models.RouterGroup
 	}{arg1})
+	stub := fake.SaveRouterGroupStub
+	fakeReturns := fake.saveRouterGroupReturns
 	fake.recordInvocation("SaveRouterGroup", []interface{}{arg1})
 	fake.saveRouterGroupMutex.Unlock()
-	if fake.SaveRouterGroupStub != nil {
-		return fake.SaveRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveRouterGroupReturns
 	return fakeReturns.result1
 }
 
@@ -926,15 +940,16 @@ func (fake *FakeDB) SaveTcpRouteMapping(arg1 models.TcpRouteMapping) error {
 	fake.saveTcpRouteMappingArgsForCall = append(fake.saveTcpRouteMappingArgsForCall, struct {
 		arg1 models.TcpRouteMapping
 	}{arg1})
+	stub := fake.SaveTcpRouteMappingStub
+	fakeReturns := fake.saveTcpRouteMappingReturns
 	fake.recordInvocation("SaveTcpRouteMapping", []interface{}{arg1})
 	fake.saveTcpRouteMappingMutex.Unlock()
-	if fake.SaveTcpRouteMappingStub != nil {
-		return fake.SaveTcpRouteMappingStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.saveTcpRouteMappingReturns
 	return fakeReturns.result1
 }
 
@@ -984,9 +999,10 @@ func (fake *FakeDB) UnlockRouterGroupReads() {
 	fake.unlockRouterGroupReadsMutex.Lock()
 	fake.unlockRouterGroupReadsArgsForCall = append(fake.unlockRouterGroupReadsArgsForCall, struct {
 	}{})
+	stub := fake.UnlockRouterGroupReadsStub
 	fake.recordInvocation("UnlockRouterGroupReads", []interface{}{})
 	fake.unlockRouterGroupReadsMutex.Unlock()
-	if fake.UnlockRouterGroupReadsStub != nil {
+	if stub != nil {
 		fake.UnlockRouterGroupReadsStub()
 	}
 }
@@ -1007,9 +1023,10 @@ func (fake *FakeDB) UnlockRouterGroupWrites() {
 	fake.unlockRouterGroupWritesMutex.Lock()
 	fake.unlockRouterGroupWritesArgsForCall = append(fake.unlockRouterGroupWritesArgsForCall, struct {
 	}{})
+	stub := fake.UnlockRouterGroupWritesStub
 	fake.recordInvocation("UnlockRouterGroupWrites", []interface{}{})
 	fake.unlockRouterGroupWritesMutex.Unlock()
-	if fake.UnlockRouterGroupWritesStub != nil {
+	if stub != nil {
 		fake.UnlockRouterGroupWritesStub()
 	}
 }
@@ -1032,15 +1049,16 @@ func (fake *FakeDB) WatchChanges(arg1 string) (<-chan db.Event, <-chan error, co
 	fake.watchChangesArgsForCall = append(fake.watchChangesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.WatchChangesStub
+	fakeReturns := fake.watchChangesReturns
 	fake.recordInvocation("WatchChanges", []interface{}{arg1})
 	fake.watchChangesMutex.Unlock()
-	if fake.WatchChangesStub != nil {
-		return fake.WatchChangesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.watchChangesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/db/fakes/fake_mysql_adapter.go
+++ b/db/fakes/fake_mysql_adapter.go
@@ -30,15 +30,16 @@ func (fake *MySQLAdapter) RegisterTLSConfig(arg1 string, arg2 *tls.Config) error
 		arg1 string
 		arg2 *tls.Config
 	}{arg1, arg2})
+	stub := fake.RegisterTLSConfigStub
+	fakeReturns := fake.registerTLSConfigReturns
 	fake.recordInvocation("RegisterTLSConfig", []interface{}{arg1, arg2})
 	fake.registerTLSConfigMutex.Unlock()
-	if fake.RegisterTLSConfigStub != nil {
-		return fake.RegisterTLSConfigStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.registerTLSConfigReturns
 	return fakeReturns.result1
 }
 

--- a/fake_routing_api/fake_client.go
+++ b/fake_routing_api/fake_client.go
@@ -227,15 +227,16 @@ func (fake *FakeClient) CreateRouterGroup(arg1 models.RouterGroup) error {
 	fake.createRouterGroupArgsForCall = append(fake.createRouterGroupArgsForCall, struct {
 		arg1 models.RouterGroup
 	}{arg1})
+	stub := fake.CreateRouterGroupStub
+	fakeReturns := fake.createRouterGroupReturns
 	fake.recordInvocation("CreateRouterGroup", []interface{}{arg1})
 	fake.createRouterGroupMutex.Unlock()
-	if fake.CreateRouterGroupStub != nil {
-		return fake.CreateRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createRouterGroupReturns
 	return fakeReturns.result1
 }
 
@@ -287,15 +288,16 @@ func (fake *FakeClient) DeleteRouterGroup(arg1 models.RouterGroup) error {
 	fake.deleteRouterGroupArgsForCall = append(fake.deleteRouterGroupArgsForCall, struct {
 		arg1 models.RouterGroup
 	}{arg1})
+	stub := fake.DeleteRouterGroupStub
+	fakeReturns := fake.deleteRouterGroupReturns
 	fake.recordInvocation("DeleteRouterGroup", []interface{}{arg1})
 	fake.deleteRouterGroupMutex.Unlock()
-	if fake.DeleteRouterGroupStub != nil {
-		return fake.DeleteRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteRouterGroupReturns
 	return fakeReturns.result1
 }
 
@@ -352,15 +354,16 @@ func (fake *FakeClient) DeleteRoutes(arg1 []models.Route) error {
 	fake.deleteRoutesArgsForCall = append(fake.deleteRoutesArgsForCall, struct {
 		arg1 []models.Route
 	}{arg1Copy})
+	stub := fake.DeleteRoutesStub
+	fakeReturns := fake.deleteRoutesReturns
 	fake.recordInvocation("DeleteRoutes", []interface{}{arg1Copy})
 	fake.deleteRoutesMutex.Unlock()
-	if fake.DeleteRoutesStub != nil {
-		return fake.DeleteRoutesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteRoutesReturns
 	return fakeReturns.result1
 }
 
@@ -417,15 +420,16 @@ func (fake *FakeClient) DeleteTcpRouteMappings(arg1 []models.TcpRouteMapping) er
 	fake.deleteTcpRouteMappingsArgsForCall = append(fake.deleteTcpRouteMappingsArgsForCall, struct {
 		arg1 []models.TcpRouteMapping
 	}{arg1Copy})
+	stub := fake.DeleteTcpRouteMappingsStub
+	fakeReturns := fake.deleteTcpRouteMappingsReturns
 	fake.recordInvocation("DeleteTcpRouteMappings", []interface{}{arg1Copy})
 	fake.deleteTcpRouteMappingsMutex.Unlock()
-	if fake.DeleteTcpRouteMappingsStub != nil {
-		return fake.DeleteTcpRouteMappingsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteTcpRouteMappingsReturns
 	return fakeReturns.result1
 }
 
@@ -482,15 +486,16 @@ func (fake *FakeClient) FilteredTcpRouteMappings(arg1 []string) ([]models.TcpRou
 	fake.filteredTcpRouteMappingsArgsForCall = append(fake.filteredTcpRouteMappingsArgsForCall, struct {
 		arg1 []string
 	}{arg1Copy})
+	stub := fake.FilteredTcpRouteMappingsStub
+	fakeReturns := fake.filteredTcpRouteMappingsReturns
 	fake.recordInvocation("FilteredTcpRouteMappings", []interface{}{arg1Copy})
 	fake.filteredTcpRouteMappingsMutex.Unlock()
-	if fake.FilteredTcpRouteMappingsStub != nil {
-		return fake.FilteredTcpRouteMappingsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.filteredTcpRouteMappingsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -546,15 +551,16 @@ func (fake *FakeClient) ReservePort(arg1 string, arg2 string) (int, error) {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ReservePortStub
+	fakeReturns := fake.reservePortReturns
 	fake.recordInvocation("ReservePort", []interface{}{arg1, arg2})
 	fake.reservePortMutex.Unlock()
-	if fake.ReservePortStub != nil {
-		return fake.ReservePortStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.reservePortReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -609,15 +615,16 @@ func (fake *FakeClient) RouterGroupWithName(arg1 string) (models.RouterGroup, er
 	fake.routerGroupWithNameArgsForCall = append(fake.routerGroupWithNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RouterGroupWithNameStub
+	fakeReturns := fake.routerGroupWithNameReturns
 	fake.recordInvocation("RouterGroupWithName", []interface{}{arg1})
 	fake.routerGroupWithNameMutex.Unlock()
-	if fake.RouterGroupWithNameStub != nil {
-		return fake.RouterGroupWithNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.routerGroupWithNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -671,15 +678,16 @@ func (fake *FakeClient) RouterGroups() ([]models.RouterGroup, error) {
 	ret, specificReturn := fake.routerGroupsReturnsOnCall[len(fake.routerGroupsArgsForCall)]
 	fake.routerGroupsArgsForCall = append(fake.routerGroupsArgsForCall, struct {
 	}{})
+	stub := fake.RouterGroupsStub
+	fakeReturns := fake.routerGroupsReturns
 	fake.recordInvocation("RouterGroups", []interface{}{})
 	fake.routerGroupsMutex.Unlock()
-	if fake.RouterGroupsStub != nil {
-		return fake.RouterGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.routerGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -726,15 +734,16 @@ func (fake *FakeClient) Routes() ([]models.Route, error) {
 	ret, specificReturn := fake.routesReturnsOnCall[len(fake.routesArgsForCall)]
 	fake.routesArgsForCall = append(fake.routesArgsForCall, struct {
 	}{})
+	stub := fake.RoutesStub
+	fakeReturns := fake.routesReturns
 	fake.recordInvocation("Routes", []interface{}{})
 	fake.routesMutex.Unlock()
-	if fake.RoutesStub != nil {
-		return fake.RoutesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.routesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -781,9 +790,10 @@ func (fake *FakeClient) SetToken(arg1 string) {
 	fake.setTokenArgsForCall = append(fake.setTokenArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.SetTokenStub
 	fake.recordInvocation("SetToken", []interface{}{arg1})
 	fake.setTokenMutex.Unlock()
-	if fake.SetTokenStub != nil {
+	if stub != nil {
 		fake.SetTokenStub(arg1)
 	}
 }
@@ -812,15 +822,16 @@ func (fake *FakeClient) SubscribeToEvents() (routing_api.EventSource, error) {
 	ret, specificReturn := fake.subscribeToEventsReturnsOnCall[len(fake.subscribeToEventsArgsForCall)]
 	fake.subscribeToEventsArgsForCall = append(fake.subscribeToEventsArgsForCall, struct {
 	}{})
+	stub := fake.SubscribeToEventsStub
+	fakeReturns := fake.subscribeToEventsReturns
 	fake.recordInvocation("SubscribeToEvents", []interface{}{})
 	fake.subscribeToEventsMutex.Unlock()
-	if fake.SubscribeToEventsStub != nil {
-		return fake.SubscribeToEventsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.subscribeToEventsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -868,15 +879,16 @@ func (fake *FakeClient) SubscribeToEventsWithMaxRetries(arg1 uint16) (routing_ap
 	fake.subscribeToEventsWithMaxRetriesArgsForCall = append(fake.subscribeToEventsWithMaxRetriesArgsForCall, struct {
 		arg1 uint16
 	}{arg1})
+	stub := fake.SubscribeToEventsWithMaxRetriesStub
+	fakeReturns := fake.subscribeToEventsWithMaxRetriesReturns
 	fake.recordInvocation("SubscribeToEventsWithMaxRetries", []interface{}{arg1})
 	fake.subscribeToEventsWithMaxRetriesMutex.Unlock()
-	if fake.SubscribeToEventsWithMaxRetriesStub != nil {
-		return fake.SubscribeToEventsWithMaxRetriesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.subscribeToEventsWithMaxRetriesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -930,15 +942,16 @@ func (fake *FakeClient) SubscribeToTcpEvents() (routing_api.TcpEventSource, erro
 	ret, specificReturn := fake.subscribeToTcpEventsReturnsOnCall[len(fake.subscribeToTcpEventsArgsForCall)]
 	fake.subscribeToTcpEventsArgsForCall = append(fake.subscribeToTcpEventsArgsForCall, struct {
 	}{})
+	stub := fake.SubscribeToTcpEventsStub
+	fakeReturns := fake.subscribeToTcpEventsReturns
 	fake.recordInvocation("SubscribeToTcpEvents", []interface{}{})
 	fake.subscribeToTcpEventsMutex.Unlock()
-	if fake.SubscribeToTcpEventsStub != nil {
-		return fake.SubscribeToTcpEventsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.subscribeToTcpEventsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -986,15 +999,16 @@ func (fake *FakeClient) SubscribeToTcpEventsWithMaxRetries(arg1 uint16) (routing
 	fake.subscribeToTcpEventsWithMaxRetriesArgsForCall = append(fake.subscribeToTcpEventsWithMaxRetriesArgsForCall, struct {
 		arg1 uint16
 	}{arg1})
+	stub := fake.SubscribeToTcpEventsWithMaxRetriesStub
+	fakeReturns := fake.subscribeToTcpEventsWithMaxRetriesReturns
 	fake.recordInvocation("SubscribeToTcpEventsWithMaxRetries", []interface{}{arg1})
 	fake.subscribeToTcpEventsWithMaxRetriesMutex.Unlock()
-	if fake.SubscribeToTcpEventsWithMaxRetriesStub != nil {
-		return fake.SubscribeToTcpEventsWithMaxRetriesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.subscribeToTcpEventsWithMaxRetriesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1048,15 +1062,16 @@ func (fake *FakeClient) TcpRouteMappings() ([]models.TcpRouteMapping, error) {
 	ret, specificReturn := fake.tcpRouteMappingsReturnsOnCall[len(fake.tcpRouteMappingsArgsForCall)]
 	fake.tcpRouteMappingsArgsForCall = append(fake.tcpRouteMappingsArgsForCall, struct {
 	}{})
+	stub := fake.TcpRouteMappingsStub
+	fakeReturns := fake.tcpRouteMappingsReturns
 	fake.recordInvocation("TcpRouteMappings", []interface{}{})
 	fake.tcpRouteMappingsMutex.Unlock()
-	if fake.TcpRouteMappingsStub != nil {
-		return fake.TcpRouteMappingsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.tcpRouteMappingsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1104,15 +1119,16 @@ func (fake *FakeClient) UpdateRouterGroup(arg1 models.RouterGroup) error {
 	fake.updateRouterGroupArgsForCall = append(fake.updateRouterGroupArgsForCall, struct {
 		arg1 models.RouterGroup
 	}{arg1})
+	stub := fake.UpdateRouterGroupStub
+	fakeReturns := fake.updateRouterGroupReturns
 	fake.recordInvocation("UpdateRouterGroup", []interface{}{arg1})
 	fake.updateRouterGroupMutex.Unlock()
-	if fake.UpdateRouterGroupStub != nil {
-		return fake.UpdateRouterGroupStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateRouterGroupReturns
 	return fakeReturns.result1
 }
 
@@ -1169,15 +1185,16 @@ func (fake *FakeClient) UpsertRoutes(arg1 []models.Route) error {
 	fake.upsertRoutesArgsForCall = append(fake.upsertRoutesArgsForCall, struct {
 		arg1 []models.Route
 	}{arg1Copy})
+	stub := fake.UpsertRoutesStub
+	fakeReturns := fake.upsertRoutesReturns
 	fake.recordInvocation("UpsertRoutes", []interface{}{arg1Copy})
 	fake.upsertRoutesMutex.Unlock()
-	if fake.UpsertRoutesStub != nil {
-		return fake.UpsertRoutesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.upsertRoutesReturns
 	return fakeReturns.result1
 }
 
@@ -1234,15 +1251,16 @@ func (fake *FakeClient) UpsertTcpRouteMappings(arg1 []models.TcpRouteMapping) er
 	fake.upsertTcpRouteMappingsArgsForCall = append(fake.upsertTcpRouteMappingsArgsForCall, struct {
 		arg1 []models.TcpRouteMapping
 	}{arg1Copy})
+	stub := fake.UpsertTcpRouteMappingsStub
+	fakeReturns := fake.upsertTcpRouteMappingsReturns
 	fake.recordInvocation("UpsertTcpRouteMappings", []interface{}{arg1Copy})
 	fake.upsertTcpRouteMappingsMutex.Unlock()
-	if fake.UpsertTcpRouteMappingsStub != nil {
-		return fake.UpsertTcpRouteMappingsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.upsertTcpRouteMappingsReturns
 	return fakeReturns.result1
 }
 

--- a/fake_routing_api/fake_event_source.go
+++ b/fake_routing_api/fake_event_source.go
@@ -39,15 +39,16 @@ func (fake *FakeEventSource) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -91,15 +92,16 @@ func (fake *FakeEventSource) Next() (routing_api.Event, error) {
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
 	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
 	}{})
+	stub := fake.NextStub
+	fakeReturns := fake.nextReturns
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
-	if fake.NextStub != nil {
-		return fake.NextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.nextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/fake_routing_api/fake_tcp_event_source.go
+++ b/fake_routing_api/fake_tcp_event_source.go
@@ -39,15 +39,16 @@ func (fake *FakeTcpEventSource) Close() error {
 	ret, specificReturn := fake.closeReturnsOnCall[len(fake.closeArgsForCall)]
 	fake.closeArgsForCall = append(fake.closeArgsForCall, struct {
 	}{})
+	stub := fake.CloseStub
+	fakeReturns := fake.closeReturns
 	fake.recordInvocation("Close", []interface{}{})
 	fake.closeMutex.Unlock()
-	if fake.CloseStub != nil {
-		return fake.CloseStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.closeReturns
 	return fakeReturns.result1
 }
 
@@ -91,15 +92,16 @@ func (fake *FakeTcpEventSource) Next() (routing_api.TcpEvent, error) {
 	ret, specificReturn := fake.nextReturnsOnCall[len(fake.nextArgsForCall)]
 	fake.nextArgsForCall = append(fake.nextArgsForCall, struct {
 	}{})
+	stub := fake.NextStub
+	fakeReturns := fake.nextReturns
 	fake.recordInvocation("Next", []interface{}{})
 	fake.nextMutex.Unlock()
-	if fake.NextStub != nil {
-		return fake.NextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.nextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/handlers/fakes/fake_validator.go
+++ b/handlers/fakes/fake_validator.go
@@ -73,15 +73,16 @@ func (fake *FakeRouteValidator) ValidateCreate(arg1 []models.Route, arg2 int) *r
 		arg1 []models.Route
 		arg2 int
 	}{arg1Copy, arg2})
+	stub := fake.ValidateCreateStub
+	fakeReturns := fake.validateCreateReturns
 	fake.recordInvocation("ValidateCreate", []interface{}{arg1Copy, arg2})
 	fake.validateCreateMutex.Unlock()
-	if fake.ValidateCreateStub != nil {
-		return fake.ValidateCreateStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateCreateReturns
 	return fakeReturns.result1
 }
 
@@ -140,15 +141,16 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMapping(arg1 []models.TcpR
 		arg2 models.RouterGroups
 		arg3 int
 	}{arg1Copy, arg2, arg3})
+	stub := fake.ValidateCreateTcpRouteMappingStub
+	fakeReturns := fake.validateCreateTcpRouteMappingReturns
 	fake.recordInvocation("ValidateCreateTcpRouteMapping", []interface{}{arg1Copy, arg2, arg3})
 	fake.validateCreateTcpRouteMappingMutex.Unlock()
-	if fake.ValidateCreateTcpRouteMappingStub != nil {
-		return fake.ValidateCreateTcpRouteMappingStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateCreateTcpRouteMappingReturns
 	return fakeReturns.result1
 }
 
@@ -205,15 +207,16 @@ func (fake *FakeRouteValidator) ValidateDelete(arg1 []models.Route) *routing_api
 	fake.validateDeleteArgsForCall = append(fake.validateDeleteArgsForCall, struct {
 		arg1 []models.Route
 	}{arg1Copy})
+	stub := fake.ValidateDeleteStub
+	fakeReturns := fake.validateDeleteReturns
 	fake.recordInvocation("ValidateDelete", []interface{}{arg1Copy})
 	fake.validateDeleteMutex.Unlock()
-	if fake.ValidateDeleteStub != nil {
-		return fake.ValidateDeleteStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateDeleteReturns
 	return fakeReturns.result1
 }
 
@@ -270,15 +273,16 @@ func (fake *FakeRouteValidator) ValidateDeleteTcpRouteMapping(arg1 []models.TcpR
 	fake.validateDeleteTcpRouteMappingArgsForCall = append(fake.validateDeleteTcpRouteMappingArgsForCall, struct {
 		arg1 []models.TcpRouteMapping
 	}{arg1Copy})
+	stub := fake.ValidateDeleteTcpRouteMappingStub
+	fakeReturns := fake.validateDeleteTcpRouteMappingReturns
 	fake.recordInvocation("ValidateDeleteTcpRouteMapping", []interface{}{arg1Copy})
 	fake.validateDeleteTcpRouteMappingMutex.Unlock()
-	if fake.ValidateDeleteTcpRouteMappingStub != nil {
-		return fake.ValidateDeleteTcpRouteMappingStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.validateDeleteTcpRouteMappingReturns
 	return fakeReturns.result1
 }
 

--- a/migration/V7_instance_id_defaults.go
+++ b/migration/V7_instance_id_defaults.go
@@ -1,0 +1,35 @@
+package migration
+
+import (
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+type V7TCPTLSRoutes struct{}
+
+func NewV7TCPTLSRoutes() *V7TCPTLSRoutes {
+	return &V7TCPTLSRoutes{}
+}
+
+func (v *V7TCPTLSRoutes) Version() int {
+	return 7
+}
+
+func (v *V7TCPTLSRoutes) Run(sqlDB *db.SqlDB) error {
+	_, err := sqlDB.Client.Model(&models.TcpRouteMapping{}).RemoveIndex("idx_tcp_route")
+	if err != nil {
+		return err
+	}
+
+	if sqlDB.Client.Dialect().GetName() == "postgres" {
+		sqlDB.Client.Exec("ALTER TABLE tcp_routes ALTER COLUMN instance_id DROP NOT NULL")
+	} else {
+		sqlDB.Client.Exec("ALTER TABLE tcp_routes MODIFY COLUMN instance_id varchar(255) DEFAULT NULL")
+	}
+
+	_, err = sqlDB.Client.Model(&models.TcpRouteMapping{}).AddUniqueIndex("idx_tcp_route", "router_group_guid", "host_port", "host_ip", "external_port", "sni_hostname", "host_tls_port")
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/migration/V7_instance_id_defaults_test.go
+++ b/migration/V7_instance_id_defaults_test.go
@@ -1,0 +1,159 @@
+package migration_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/migration"
+	v6 "code.cloudfoundry.org/routing-api/migration/v6"
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V7TCPTLSRoutes", func() {
+	var (
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
+	)
+
+	BeforeEach(func() {
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
+		Expect(err).NotTo(HaveOccurred())
+
+		sqlDB, err = db.NewSqlDB(sqlCfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := dbAllocator.Delete()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	runTests := func() {
+		Context("during migration", func() {
+			It("allows the migration to occur", func() {
+				v7Migration := migration.NewV7TCPTLSRoutes()
+				err := v7Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+				Expect(routes[0].InstanceId).To(Equal(""))
+				Expect(routes[0].HostTLSPort).To(Equal(0))
+			})
+
+		})
+		Context("After migration", func() {
+			BeforeEach(func() {
+				v7Migration := migration.NewV7TCPTLSRoutes()
+				err := v7Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-1"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId1",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("allows adding non-tls TCP routes without instance-ids", func() {
+				sniHostname2 := "sniHostname2"
+				tcpRoute2 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-2"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname2,
+					},
+				}
+				_, err := sqlDB.Client.Create(&tcpRoute2)
+				Expect(err).NotTo(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(3))
+			})
+		})
+	}
+
+	Describe("Version", func() {
+		It("returns 7 for the version", func() {
+			v7Migration := migration.NewV7TCPTLSRoutes()
+			Expect(v7Migration.Version()).To(Equal(7))
+		})
+	})
+
+	Describe("Run", func() {
+		Context("when there are existing tables with the old tcp_route model", func() {
+			BeforeEach(func() {
+				err := sqlDB.Client.AutoMigrate(&v6.RouterGroupDB{}, &v6.TcpRouteMapping{}, &v6.Route{})
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := v6.TcpRouteMapping{
+					Model:     v6.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: v6.TcpMappingEntity{
+						RouterGroupGuid: "test0",
+						HostPort:        80,
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				v6Migration := migration.NewV6TCPTLSRoutes()
+				err = v6Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+
+		Context("when the tables are newly created (by V0 init migration)", func() {
+			BeforeEach(func() {
+				v0Migration := migration.NewV0InitMigration()
+				err := v0Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := v6.TcpRouteMapping{
+					Model:     v6.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: v6.TcpMappingEntity{
+						RouterGroupGuid: "test0",
+						HostPort:        80,
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			runTests()
+		})
+	})
+})

--- a/migration/fakes/fake_migration.go
+++ b/migration/fakes/fake_migration.go
@@ -40,15 +40,16 @@ func (fake *FakeMigration) Run(arg1 *db.SqlDB) error {
 	fake.runArgsForCall = append(fake.runArgsForCall, struct {
 		arg1 *db.SqlDB
 	}{arg1})
+	stub := fake.RunStub
+	fakeReturns := fake.runReturns
 	fake.recordInvocation("Run", []interface{}{arg1})
 	fake.runMutex.Unlock()
-	if fake.RunStub != nil {
-		return fake.RunStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.runReturns
 	return fakeReturns.result1
 }
 
@@ -99,15 +100,16 @@ func (fake *FakeMigration) Version() int {
 	ret, specificReturn := fake.versionReturnsOnCall[len(fake.versionArgsForCall)]
 	fake.versionArgsForCall = append(fake.versionArgsForCall, struct {
 	}{})
+	stub := fake.VersionStub
+	fakeReturns := fake.versionReturns
 	fake.recordInvocation("Version", []interface{}{})
 	fake.versionMutex.Unlock()
-	if fake.VersionStub != nil {
-		return fake.VersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.versionReturns
 	return fakeReturns.result1
 }
 

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -85,6 +85,9 @@ func InitializeMigrations() []Migration {
 	migration = NewV6TCPTLSRoutes()
 	migrations = append(migrations, migration)
 
+	migration = NewV7TCPTLSRoutes()
+	migrations = append(migrations, migration)
+
 	return migrations
 }
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Migration", func() {
 				done := make(chan struct{})
 				defer close(done)
 				migrations := migration.InitializeMigrations()
-				Expect(migrations).To(HaveLen(6))
+				Expect(migrations).To(HaveLen(7))
 
 				Expect(migrations[0]).To(BeAssignableToTypeOf(new(migration.V0InitMigration)))
 				Expect(migrations[1]).To(BeAssignableToTypeOf(new(migration.V2UpdateRgMigration)))
@@ -51,6 +51,7 @@ var _ = Describe("Migration", func() {
 				Expect(migrations[3]).To(BeAssignableToTypeOf(new(migration.V4AddRgUniqIdxTCPRoute)))
 				Expect(migrations[4]).To(BeAssignableToTypeOf(new(migration.V5SniHostnameMigration)))
 				Expect(migrations[5]).To(BeAssignableToTypeOf(new(migration.V6TCPTLSRoutes)))
+				Expect(migrations[6]).To(BeAssignableToTypeOf(new(migration.V7TCPTLSRoutes)))
 			})
 		})
 

--- a/migration/v6/model.go
+++ b/migration/v6/model.go
@@ -1,0 +1,9 @@
+package models
+
+import "time"
+
+type Model struct {
+	Guid      string    `gorm:"primary_key" json:"-"`
+	CreatedAt time.Time `json:"-"`
+	UpdatedAt time.Time `json:"-"`
+}

--- a/migration/v6/models_suite_test.go
+++ b/migration/v6/models_suite_test.go
@@ -1,0 +1,13 @@
+package models_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestModels(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Models Suite")
+}

--- a/migration/v6/models_test.go
+++ b/migration/v6/models_test.go
@@ -1,0 +1,470 @@
+package models_test
+
+import (
+	"encoding/json"
+
+	. "code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Models", func() {
+	Describe("ModificationTag", func() {
+		var tag ModificationTag
+
+		BeforeEach(func() {
+			tag = ModificationTag{Guid: "guid1", Index: 5}
+		})
+
+		Describe("Increment", func() {
+			BeforeEach(func() {
+				tag.Increment()
+			})
+
+			It("Increments the index", func() {
+				Expect(tag.Index).To(Equal(uint32(6)))
+			})
+		})
+
+		Describe("SucceededBy", func() {
+			var tag2 ModificationTag
+
+			Context("when the guid is the different", func() {
+				BeforeEach(func() {
+					tag2 = ModificationTag{Guid: "guid5", Index: 0}
+				})
+				It("new tag should succeed", func() {
+					Expect(tag.SucceededBy(&tag2)).To(BeTrue())
+				})
+			})
+
+			Context("when the guid is the same", func() {
+
+				Context("when the index is the same as the original tag", func() {
+					BeforeEach(func() {
+						tag2 = ModificationTag{Guid: "guid1", Index: 5}
+					})
+
+					It("new tag should not succeed", func() {
+						Expect(tag.SucceededBy(&tag2)).To(BeFalse())
+					})
+
+				})
+
+				Context("when the index is less than original tag Index", func() {
+
+					BeforeEach(func() {
+						tag2 = ModificationTag{Guid: "guid1", Index: 4}
+					})
+
+					It("new tag should not succeed", func() {
+						Expect(tag.SucceededBy(&tag2)).To(BeFalse())
+					})
+				})
+
+				Context("when the index is greater than original tag Index", func() {
+					BeforeEach(func() {
+						tag2 = ModificationTag{Guid: "guid1", Index: 6}
+					})
+
+					It("new tag should succeed", func() {
+						Expect(tag.SucceededBy(&tag2)).To(BeTrue())
+					})
+
+				})
+
+			})
+
+		})
+	})
+
+	Describe("RouterGroup", func() {
+		var rg RouterGroup
+
+		Describe("Validate", func() {
+			It("does not allow ReservablePorts for http type", func() {
+				rg = RouterGroup{
+					Name:            "router-group-1",
+					Type:            "http",
+					ReservablePorts: "1025-2025",
+				}
+				err := rg.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Reservable ports are not supported for router groups of type http"))
+				By("not having ReservablePorts")
+				rg = RouterGroup{
+					Name: "router-group-1",
+					Type: "http",
+				}
+				err = rg.Validate()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("ReservablePorts are optional for non-http, non-tcp type", func() {
+				rg = RouterGroup{
+					Name:            "router-group-1",
+					Type:            "foo",
+					ReservablePorts: "1025-2025",
+				}
+				err := rg.Validate()
+				Expect(err).ToNot(HaveOccurred())
+
+				rg = RouterGroup{
+					Name:            "router-group-1",
+					Type:            "foo",
+					ReservablePorts: "",
+				}
+				err = rg.Validate()
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("succeeds for valid router group", func() {
+				rg = RouterGroup{
+					Name:            "router-group-1",
+					Type:            "tcp",
+					ReservablePorts: "1025-2025",
+				}
+				err := rg.Validate()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("fails for missing type", func() {
+				rg = RouterGroup{
+					Name:            "router-group-1",
+					ReservablePorts: "10-20",
+				}
+				err := rg.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Missing type in router group"))
+			})
+			It("fails for missing name", func() {
+				rg = RouterGroup{
+					Type:            "tcp",
+					ReservablePorts: "10-20",
+				}
+				err := rg.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Missing name in router group"))
+			})
+
+			It("fails for missing ReservablePorts", func() {
+				rg = RouterGroup{
+					Type: "tcp",
+					Name: "router-group-1",
+				}
+				err := rg.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Missing reservable_ports in router group: router-group-1"))
+			})
+
+			Context("when there are reserved system component ports", func() {
+				BeforeEach(func() {
+					ReservedSystemComponentPorts = []int{5555, 6666, 7777}
+				})
+
+				Context("when failOnRouterPortConflicts is true", func() {
+					BeforeEach(func() {
+						FailOnRouterPortConflicts = true
+					})
+
+					It("succeeds when the ports don't overlap", func() {
+						rg = RouterGroup{
+							Name:            "router-group-1",
+							Type:            "tcp",
+							ReservablePorts: "1025-2025",
+						}
+						err := rg.Validate()
+						Expect(err).ToNot(HaveOccurred())
+					})
+
+					It("fails when the ports overlap", func() {
+						rg = RouterGroup{
+							Name:            "router-group-1",
+							Type:            "tcp",
+							ReservablePorts: "5000-6000",
+						}
+						err := rg.Validate()
+						Expect(err).To(HaveOccurred())
+						Expect(err).To(MatchError("Invalid ports. Reservable ports must not include the following reserved system component ports: [5555 6666 7777]."))
+					})
+
+					Context("when failOnRouterPortConflicts is false", func() {
+
+						BeforeEach(func() {
+							FailOnRouterPortConflicts = false
+						})
+
+						It("succeeds when the ports don't overlap", func() {
+							rg = RouterGroup{
+								Name:            "router-group-1",
+								Type:            "tcp",
+								ReservablePorts: "1025-2025",
+							}
+							err := rg.Validate()
+							Expect(err).ToNot(HaveOccurred())
+						})
+
+						It("succeeds when the ports overlap", func() {
+							rg = RouterGroup{
+								Name:            "router-group-1",
+								Type:            "tcp",
+								ReservablePorts: "5000-6000",
+							}
+							err := rg.Validate()
+							Expect(err).ToNot(HaveOccurred())
+						})
+					})
+				})
+			})
+		})
+	})
+
+	Describe("ReservablePorts", func() {
+		var ports ReservablePorts
+
+		Describe("Validate", func() {
+			It("succeeds for valid reservable ports", func() {
+				ports = "6001,6005,6010-6020,6021-6030"
+				err := ports.Validate()
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("fails for overlapping ranges", func() {
+				ports = "6010-6020,6020-6030"
+				err := ports.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Overlapping values: [6010-6020] and [6020-6030]"))
+			})
+
+			It("fails for overlapping values", func() {
+				ports = "6001,6001,6002,6003,6003,6004"
+				err := ports.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("Overlapping values: 6001 and 6001"))
+			})
+
+			It("fails for invalid reservable ports", func() {
+				ports = "foo!"
+				err := ports.Validate()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Describe("Parse", func() {
+			It("validates a single unsigned integer", func() {
+				ports = "9999"
+				r, err := ports.Parse()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(r)).To(Equal(1))
+				start, end := r[0].Endpoints()
+				Expect(start).To(Equal(uint64(9999)))
+				Expect(end).To(Equal(uint64(9999)))
+			})
+
+			It("validates multiple integers", func() {
+				ports = "9999,1111,2222"
+				r, err := ports.Parse()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(r)).To(Equal(3))
+
+				expected := []uint64{9999, 1111, 2222}
+				for i := 0; i < len(r); i++ {
+					start, end := r[i].Endpoints()
+					Expect(start).To(Equal(expected[i]))
+					Expect(end).To(Equal(expected[i]))
+				}
+			})
+
+			It("validates a range", func() {
+				ports = "10241-10249"
+				r, err := ports.Parse()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(r)).To(Equal(1))
+				start, end := r[0].Endpoints()
+				Expect(start).To(Equal(uint64(10241)))
+				Expect(end).To(Equal(uint64(10249)))
+			})
+
+			It("validates a list of ranges and integers", func() {
+				ports = "6001-6010,6020-6022,6045,6050-6060"
+				r, err := ports.Parse()
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(len(r)).To(Equal(4))
+				expected := []uint64{6001, 6010, 6020, 6022, 6045, 6045, 6050, 6060}
+				for i := 0; i < len(r); i++ {
+					start, end := r[i].Endpoints()
+					Expect(start).To(Equal(expected[2*i]))
+					Expect(end).To(Equal(expected[2*i+1]))
+				}
+			})
+
+			It("errors on range with 3 dashes", func() {
+				ports = "10-999-1000"
+				_, err := ports.Parse()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("range (10-999-1000) has too many '-' separators"))
+			})
+
+			It("errors on a negative integer", func() {
+				ports = "-9999"
+				_, err := ports.Parse()
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("errors on a incomplete range", func() {
+				ports = "1030-"
+				_, err := ports.Parse()
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("errors on non-numeric input", func() {
+				ports = "adsfasdf"
+				_, err := ports.Parse()
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("errors when range starts with lower number", func() {
+				ports = "10000-9999"
+				_, err := ports.Parse()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("range (10000-9999) must be in ascending numeric order"))
+			})
+		})
+	})
+
+	Describe("Range", func() {
+		Describe("Overlaps", func() {
+			testRange, _ := NewRange(6010, 6020)
+
+			It("validates non-overlapping ranges", func() {
+				r, _ := NewRange(6021, 6030)
+				Expect(testRange.Overlaps(r)).To(BeFalse())
+			})
+
+			It("finds overlapping ranges of single values", func() {
+				r1, _ := NewRange(6010, 6010)
+				r2, _ := NewRange(6010, 6010)
+				Expect(r1.Overlaps(r2)).To(BeTrue())
+			})
+
+			It("finds overlapping ranges of single value and range", func() {
+				r2, _ := NewRange(6015, 6015)
+				Expect(testRange.Overlaps(r2)).To(BeTrue())
+			})
+
+			It("finds overlapping ranges of single value upper bound and range", func() {
+				r2, _ := NewRange(6020, 6020)
+				Expect(testRange.Overlaps(r2)).To(BeTrue())
+			})
+
+			It("validates single value one above upper bound range", func() {
+				r2, _ := NewRange(6021, 6021)
+				Expect(testRange.Overlaps(r2)).To(BeFalse())
+			})
+
+			It("finds overlapping ranges when start overlaps", func() {
+				r, _ := NewRange(6015, 6030)
+				Expect(testRange.Overlaps(r)).To(BeTrue())
+			})
+
+			It("finds overlapping ranges when end overlaps", func() {
+				r, _ := NewRange(6005, 6015)
+				Expect(testRange.Overlaps(r)).To(BeTrue())
+			})
+
+			It("finds overlapping ranges when the range is a superset", func() {
+				r, _ := NewRange(6009, 6021)
+				Expect(testRange.Overlaps(r)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("Route", func() {
+		var (
+			route Route
+		)
+
+		BeforeEach(func() {
+			tag, err := NewModificationTag()
+			Expect(err).ToNot(HaveOccurred())
+			route = NewRoute("/foo/bar", 35, "2.2.2.2", "", "banana", 66)
+			route.ModificationTag = tag
+		})
+
+		Describe("SetDefaults", func() {
+			JustBeforeEach(func() {
+				route.SetDefaults(120)
+			})
+
+			Context("when ttl is nil", func() {
+				BeforeEach(func() {
+					route.TTL = nil
+				})
+
+				It("sets the default ttl", func() {
+					Expect(*route.TTL).To(Equal(120))
+				})
+			})
+
+			Context("when ttl is not nil", func() {
+				It("does not change ttl", func() {
+					Expect(*route.TTL).To(Equal(66))
+				})
+			})
+		})
+	})
+
+	Describe("TcpRouteMapping", func() {
+		var (
+			route TcpRouteMapping
+		)
+
+		BeforeEach(func() {
+			tag, err := NewModificationTag()
+			Expect(err).ToNot(HaveOccurred())
+			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag)
+		})
+
+		Describe("SetDefaults", func() {
+			JustBeforeEach(func() {
+				route.SetDefaults(120)
+			})
+
+			Context("when ttl is nil", func() {
+				BeforeEach(func() {
+					route.TTL = nil
+				})
+
+				It("sets default ttl", func() {
+					Expect(*route.TTL).To(Equal(120))
+				})
+			})
+
+			Context("when ttl is not nil", func() {
+				It("doesn't change ttl", func() {
+					Expect(*route.TTL).To(Equal(66))
+				})
+			})
+		})
+
+		Context("multiple annotations", func() {
+			It("return router group object", func() {
+				jsonStr :=
+					`
+{ "guid": "some-guid",
+	"name": "name"
+}
+`
+				rg := RouterGroup{}
+				err := json.Unmarshal([]byte(jsonStr), &rg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rg.Guid).To(Equal("some-guid"))
+				Expect(rg.Name).To(Equal("name"))
+			})
+		})
+	})
+})

--- a/migration/v6/route.go
+++ b/migration/v6/route.go
@@ -1,0 +1,91 @@
+package models
+
+import (
+	"time"
+
+	uuid "github.com/nu7hatch/gouuid"
+)
+
+type Route struct {
+	Model
+	ExpiresAt time.Time `json:"-"`
+	RouteEntity
+}
+
+type RouteEntity struct {
+	Route           string `gorm:"not null; unique_index:idx_route" json:"route"`
+	Port            uint16 `gorm:"not null; unique_index:idx_route" json:"port"`
+	IP              string `gorm:"not null; unique_index:idx_route" json:"ip"`
+	TTL             *int   `json:"ttl"`
+	LogGuid         string `json:"log_guid"`
+	RouteServiceUrl string `gorm:"not null; unique_index:idx_route" json:"route_service_url,omitempty"`
+	ModificationTag `json:"modification_tag"`
+}
+
+func NewRouteWithModel(route Route) (Route, error) {
+	guid, err := uuid.NewV4()
+	if err != nil {
+		return Route{}, err
+	}
+
+	return Route{
+		ExpiresAt:   time.Now().Add(time.Duration(*route.TTL) * time.Second),
+		Model:       Model{Guid: guid.String()},
+		RouteEntity: route.RouteEntity,
+	}, nil
+}
+func NewRoute(url string, port uint16, ip, logGuid, routeServiceUrl string, ttl int) Route {
+	route := RouteEntity{
+		Route:           url,
+		Port:            port,
+		IP:              ip,
+		TTL:             &ttl,
+		LogGuid:         logGuid,
+		RouteServiceUrl: routeServiceUrl,
+	}
+	return Route{
+		RouteEntity: route,
+	}
+}
+
+func NewModificationTag() (ModificationTag, error) {
+	uuid, err := uuid.NewV4()
+	if err != nil {
+		return ModificationTag{}, err
+	}
+
+	return ModificationTag{
+		Guid:  uuid.String(),
+		Index: 0,
+	}, nil
+}
+
+func (t *ModificationTag) Increment() {
+	t.Index++
+}
+
+func (m *ModificationTag) SucceededBy(other *ModificationTag) bool {
+	if m == nil || m.Guid == "" || other.Guid == "" {
+		return true
+	}
+
+	return m.Guid != other.Guid || m.Index < other.Index
+}
+
+func (r Route) GetTTL() int {
+	if r.TTL == nil {
+		return 0
+	}
+	return *r.TTL
+}
+
+func (r *Route) SetDefaults(defaultTTL int) {
+	if r.TTL == nil {
+		r.TTL = &defaultTTL
+	}
+}
+
+type ModificationTag struct {
+	Guid  string `gorm:"column:modification_guid" json:"guid"`
+	Index uint32 `gorm:"column:modification_index" json:"index"`
+}

--- a/migration/v6/router_groups.go
+++ b/migration/v6/router_groups.go
@@ -1,0 +1,284 @@
+package models
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var InvalidPortError = errors.New("Port must be between 1024 and 65535")
+
+type RouterGroupType string
+
+var ReservedSystemComponentPorts = []int{}
+var FailOnRouterPortConflicts = false
+
+const (
+	RouterGroup_TCP  RouterGroupType = "tcp"
+	RouterGroup_HTTP RouterGroupType = "http"
+)
+
+type RouterGroupsDB []RouterGroupDB
+
+type RouterGroupDB struct {
+	Model
+	Name            string
+	Type            string
+	ReservablePorts string
+}
+
+type RouterGroup struct {
+	Model
+	Guid            string          `json:"guid"`
+	Name            string          `json:"name"`
+	Type            RouterGroupType `json:"type"`
+	ReservablePorts ReservablePorts `json:"reservable_ports" yaml:"reservable_ports"`
+}
+
+func NewRouterGroupDB(routerGroup RouterGroup) RouterGroupDB {
+	if routerGroup.Model.Guid == "" {
+		routerGroup.Model = Model{
+			Guid: routerGroup.Guid,
+		}
+	}
+	return RouterGroupDB{
+		Model:           routerGroup.Model,
+		Name:            routerGroup.Name,
+		Type:            string(routerGroup.Type),
+		ReservablePorts: string(routerGroup.ReservablePorts),
+	}
+}
+
+func (RouterGroupDB) TableName() string {
+	return "router_groups"
+}
+
+func (rg *RouterGroupDB) ToRouterGroup() RouterGroup {
+	return RouterGroup{
+		Model:           rg.Model,
+		Guid:            rg.Guid,
+		Name:            rg.Name,
+		Type:            RouterGroupType(rg.Type),
+		ReservablePorts: ReservablePorts(rg.ReservablePorts),
+	}
+}
+
+func (rgs RouterGroupsDB) ToRouterGroups() RouterGroups {
+	routerGroups := RouterGroups{}
+	for _, routerGroupDB := range rgs {
+		routerGroups = append(routerGroups, routerGroupDB.ToRouterGroup())
+	}
+	return routerGroups
+}
+
+type RouterGroups []RouterGroup
+
+func (g RouterGroups) Validate() error {
+	for _, r := range g {
+		if err := r.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g RouterGroup) Validate() error {
+	if g.Name == "" {
+		return errors.New("Missing name in router group")
+	}
+
+	if g.Type == "" {
+		return errors.New("Missing type in router group")
+	}
+
+	if g.ReservablePorts == "" {
+		if g.Type == RouterGroup_TCP {
+			return fmt.Errorf("Missing reservable_ports in router group: %s", g.Name)
+		}
+
+		return nil
+	}
+
+	if g.Type == RouterGroup_HTTP {
+		return errors.New("Reservable ports are not supported for router groups of type http")
+	}
+
+	return g.ReservablePorts.Validate()
+
+}
+
+type ReservablePorts string
+
+func (p *ReservablePorts) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var input interface{}
+
+	err := unmarshal(&input)
+	if err != nil {
+		return err // untested
+	}
+
+	switch t := input.(type) {
+	case int:
+		*p = ReservablePorts(strconv.Itoa(t))
+	case string:
+		*p = ReservablePorts(input.(string))
+	case []interface{}:
+		var s []string
+
+		for _, v := range t {
+			val, ok := v.(int)
+			if !ok {
+				return errors.New("invalid type for reservable port")
+			}
+
+			s = append(s, strconv.Itoa(val))
+		}
+
+		*p = ReservablePorts(strings.Join(s, ","))
+	default:
+		return errors.New("reservable port unmarshal failed") // untested
+	}
+
+	return nil
+}
+
+func (p ReservablePorts) Validate() error {
+	portRanges, err := p.Parse()
+	if err != nil {
+		return err
+	}
+
+	// check for overlapping ranges
+	for i, r1 := range portRanges {
+		for j, r2 := range portRanges {
+			if i == j {
+				continue
+			}
+			if r1.Overlaps(r2) {
+				errMsg := fmt.Sprintf("Overlapping values: %s and %s", r1.String(), r2.String())
+				return errors.New(errMsg)
+			}
+		}
+	}
+	// check if ports overlap with reservedSystemComponentPorts
+	if FailOnRouterPortConflicts {
+		for _, r1 := range portRanges {
+			for _, reservedPort := range ReservedSystemComponentPorts {
+
+				if uint64(reservedPort) >= r1.start && uint64(reservedPort) <= r1.end {
+					errMsg := fmt.Sprintf("Invalid ports. Reservable ports must not include the following reserved system component ports: %v.", ReservedSystemComponentPorts)
+					return errors.New(errMsg)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (p ReservablePorts) Parse() (Ranges, error) {
+	rangesArray := strings.Split(string(p), ",")
+	var ranges Ranges
+
+	for _, p := range rangesArray {
+		r, err := parseRange(p)
+		if err != nil {
+			return Ranges{}, err
+		} else {
+			ranges = append(ranges, r)
+		}
+	}
+
+	return ranges, nil
+}
+
+type Range struct {
+	start uint64 // inclusive
+	end   uint64 // inclusive
+}
+type Ranges []Range
+
+func portIsInRange(port uint64) bool {
+	return port >= 1024 && port <= 65535
+}
+
+func NewRange(start, end uint64) (Range, error) {
+	if portIsInRange(start) && portIsInRange(end) {
+		return Range{
+			start: start,
+			end:   end,
+		}, nil
+	}
+	return Range{}, InvalidPortError
+}
+
+func (r Range) Overlaps(other Range) bool {
+	maxUpper := r.max(other)
+	minLower := r.min(other)
+	// check bounds for both, then see if size of both fit
+	// For example: 10-20 and 15-30
+	// |----10-20----|
+	//         |-------15-30------|
+	// |==========================|
+	// 	minLower: 10  maxUpper: 30
+	//  (30 - 10) <= (20 - 10) + (30 - 15)
+	//         20 <= 25?
+	return maxUpper-minLower <= (r.end-r.start)+(other.end-other.start)
+}
+
+func (r Range) String() string {
+	if r.start == r.end {
+		return fmt.Sprintf("%d", r.start)
+	}
+	return fmt.Sprintf("[%d-%d]", r.start, r.end)
+}
+
+func (r Range) max(other Range) uint64 {
+	if r.end > other.end {
+		return r.end
+	}
+	return other.end
+}
+
+func (r Range) min(other Range) uint64 {
+	if r.start < other.start {
+		return r.start
+	}
+	return other.start
+}
+
+func (r Range) Endpoints() (uint64, uint64) {
+	return r.start, r.end
+}
+
+func parseRange(r string) (Range, error) {
+	endpoints := strings.Split(r, "-")
+
+	len := len(endpoints)
+	switch len {
+	case 1:
+		n, err := strconv.ParseUint(endpoints[0], 10, 64)
+		if err != nil {
+			return Range{}, InvalidPortError
+		}
+		return NewRange(n, n)
+	case 2:
+		start, err := strconv.ParseUint(endpoints[0], 10, 64)
+		if err != nil {
+			return Range{}, fmt.Errorf("range (%s) requires a starting port", r)
+		}
+
+		end, err := strconv.ParseUint(endpoints[1], 10, 64)
+		if err != nil {
+			return Range{}, fmt.Errorf("range (%s) requires an ending port", r)
+		}
+
+		if start > end {
+			return Range{}, fmt.Errorf("range (%s) must be in ascending numeric order", r)
+		}
+
+		return NewRange(start, end)
+	default:
+		return Range{}, fmt.Errorf("range (%s) has too many '-' separators", r)
+	}
+}

--- a/migration/v6/tcp_route.go
+++ b/migration/v6/tcp_route.go
@@ -22,7 +22,7 @@ type TcpMappingEntity struct {
 	// We don't add uniqueness on InstanceId so that if a route is attempted to be created with the same detals but
 	// different InstanceId, we fail uniqueness and prevent stale/duplicate routes. If this fails a route, the
 	// TTL on the old record should expire + allow the new route to be created eventually.
-	InstanceId       string `gorm:"null; default:null;" json:"instance_id"`
+	InstanceId       string `gorm:"not null;" json:"instance_id"`
 	ExternalPort     uint16 `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
 	ModificationTag  `json:"modification_tag"`
 	TTL              *int   `json:"ttl,omitempty"`

--- a/migration/v6/tcp_route_test.go
+++ b/migration/v6/tcp_route_test.go
@@ -1,0 +1,110 @@
+package models_test
+
+import (
+	"encoding/json"
+
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func pointertoString(s string) *string { return &s }
+
+var _ = Describe("TCP Route", func() {
+	Describe("TcpMappingEntity", func() {
+		var tcpRouteMapping models.TcpRouteMapping
+		var sniHostNamePtr *string
+
+		JustBeforeEach(func() {
+			tcpRouteMapping = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr, 5, models.ModificationTag{})
+		})
+		Describe("SNI Hostname", func() {
+			Context("when the SNI hostname is nil", func() {
+				BeforeEach(func() {
+					sniHostNamePtr = nil
+				})
+				It("comes through as nil", func() {
+					Expect(tcpRouteMapping.SniHostname).To(BeNil())
+				})
+				It("is omitted from JSON  marshaling", func() {
+					j, err := json.Marshal(tcpRouteMapping)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(j)).NotTo(ContainSubstring("backend_sni_hostname"))
+				})
+			})
+
+			Context("when a valid SNI hostname is provided", func() {
+				BeforeEach(func() {
+					sniHostNamePtr = pointertoString("sniHostname")
+				})
+
+				It("Accepts the value", func() {
+					Expect(*tcpRouteMapping.SniHostname).To(Equal("sniHostname"))
+				})
+				It("is provided in the marshaled JSON", func() {
+					j, err := json.Marshal(tcpRouteMapping)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(j)).To(ContainSubstring("backend_sni_hostname"))
+				})
+			})
+			Context("when the SNI hostname is empty", func() {
+				BeforeEach(func() {
+					sniHostNamePtr = pointertoString("")
+				})
+				It("is provided in the marshaled JSON", func() {
+					j, err := json.Marshal(tcpRouteMapping)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(j)).To(ContainSubstring("backend_sni_hostname"))
+				})
+			})
+		})
+		Describe("Matches()", func() {
+			var tcpRouteMapping2 models.TcpRouteMapping
+			var sniHostNamePtr2 *string
+
+			BeforeEach(func() {
+				sniHostNamePtr = pointertoString("sniHostName")
+			})
+
+			JustBeforeEach(func() {
+				tcpRouteMapping2 = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr2, 5, models.ModificationTag{})
+			})
+
+			Context("when two routes have the same SNIHostName value", func() {
+				BeforeEach(func() {
+					sniHostNamePtr2 = sniHostNamePtr
+				})
+				It("matches", func() {
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+			})
+			Context("when two routes have equal values", func() {
+				BeforeEach(func() {
+					sniHostNamePtr2 = pointertoString("sniHostName")
+				})
+				It("matches", func() {
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+			})
+
+			Context("when two routes have values that are not equal", func() {
+				BeforeEach(func() {
+					sniHostNamePtr2 = pointertoString("sniHostName2")
+				})
+				It("doesn't match", func() {
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeFalse())
+				})
+			})
+			Context("when one of the routes has a nil SNIHostName", func() {
+				BeforeEach(func() {
+					sniHostNamePtr2 = nil
+				})
+				It("doesn't match", func() {
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeFalse())
+					Expect(tcpRouteMapping2.Matches(tcpRouteMapping)).To(BeFalse())
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
… gorm has a bug and won't do it

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Gorm has a bug and doesn't trigger any updates when running AutoMigrate to fix schema that is only removing `not null` from the column definition. We have to do this manually.

Backward Compatibility
---------------
Breaking Change? no
