### PR TITLE
Cleanup

### DIFF
--- a/admin/server_test.go
+++ b/admin/server_test.go
@@ -1,14 +1,14 @@
 package admin_test
 
 import (
+	"code.cloudfoundry.org/routing-api/test_helpers"
 	"fmt"
 	"net/http"
 	"os"
 
 	"code.cloudfoundry.org/lager/v3/lagertest"
 	"code.cloudfoundry.org/routing-api/admin"
-	fake_db "code.cloudfoundry.org/routing-api/db/fakes"
-	"code.cloudfoundry.org/routing-api/test_helpers"
+	fakeDB "code.cloudfoundry.org/routing-api/db/fakes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/tedsuo/ifrit"
@@ -18,12 +18,12 @@ import (
 var _ = Describe("AdminServer", func() {
 	var (
 		logger  *lagertest.TestLogger
-		db      *fake_db.FakeDB
+		db      *fakeDB.FakeDB
 		port    int
 		process ifrit.Process
 	)
 	BeforeEach(func() {
-		db = new(fake_db.FakeDB)
+		db = new(fakeDB.FakeDB)
 		logger = lagertest.NewTestLogger("routing-api-test")
 		port = test_helpers.NextAvailPort()
 		server, err := admin.NewServer(port, db, logger)
@@ -38,7 +38,7 @@ var _ = Describe("AdminServer", func() {
 	})
 
 	DescribeTable("testing the admin endpoint",
-		func(endpoint string, callCountFn func(db *fake_db.FakeDB) int) {
+		func(endpoint string, callCountFn func(db *fakeDB.FakeDB) int) {
 			req, _ := http.NewRequest("PUT", fmt.Sprintf("http://127.0.0.1:%d/%s", port, endpoint), nil)
 			resp, err := http.DefaultClient.Do(req)
 			Expect(err).ToNot(HaveOccurred())
@@ -47,16 +47,16 @@ var _ = Describe("AdminServer", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 			Expect(callCountFn(db)).To(Equal(1))
 		},
-		Entry(`"lock_router_group_reads"`, "lock_router_group_reads", func(db *fake_db.FakeDB) int {
+		Entry(`"lock_router_group_reads"`, "lock_router_group_reads", func(db *fakeDB.FakeDB) int {
 			return db.LockRouterGroupReadsCallCount()
 		}),
-		Entry(`"unlock_router_group_reads"`, "unlock_router_group_reads", func(db *fake_db.FakeDB) int {
+		Entry(`"unlock_router_group_reads"`, "unlock_router_group_reads", func(db *fakeDB.FakeDB) int {
 			return db.UnlockRouterGroupReadsCallCount()
 		}),
-		Entry(`"lock_router_group_writes"`, "lock_router_group_writes", func(db *fake_db.FakeDB) int {
+		Entry(`"lock_router_group_writes"`, "lock_router_group_writes", func(db *fakeDB.FakeDB) int {
 			return db.LockRouterGroupWritesCallCount()
 		}),
-		Entry(`"unlock_router_group_writes"`, "unlock_router_group_writes", func(db *fake_db.FakeDB) int {
+		Entry(`"unlock_router_group_writes"`, "unlock_router_group_writes", func(db *fakeDB.FakeDB) int {
 			return db.UnlockRouterGroupWritesCallCount()
 		}),
 	)

--- a/cmd/routing-api/cert_helper_test.go
+++ b/cmd/routing-api/cert_helper_test.go
@@ -1,7 +1,7 @@
 package main_test
 
 import (
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/test_helpers"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -102,7 +102,7 @@ func createCertTemplate(certType CertType) (x509.Certificate, error) {
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().AddDate(10, 0, 0),
 		BasicConstraintsValid: true,
-		IPAddresses:           []net.IP{net.ParseIP(testrunner.RoutingAPIIP)},
+		IPAddresses:           []net.IP{net.ParseIP(test_helpers.RoutingAPIIP)},
 	}
 
 	switch certType {

--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -16,7 +16,7 @@ import (
 	"code.cloudfoundry.org/locket"
 	"code.cloudfoundry.org/locket/lock"
 	locketmodels "code.cloudfoundry.org/locket/models"
-	routing_api "code.cloudfoundry.org/routing-api"
+	routingAPI "code.cloudfoundry.org/routing-api"
 	"code.cloudfoundry.org/routing-api/admin"
 	"code.cloudfoundry.org/routing-api/config"
 	"code.cloudfoundry.org/routing-api/db"
@@ -37,10 +37,7 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-const (
-	sessionName     = "routing_api"
-	pruningInterval = 10 * time.Second
-)
+const pruningInterval = 10 * time.Second
 
 var configPath = flag.String("config", "", "Configuration for routing-api")
 var devMode = flag.Bool("devMode", false, "Disable authentication for easier development iteration")
@@ -125,7 +122,7 @@ func main() {
 	}
 
 	lockIdentifier := &locketmodels.Resource{
-		Key:      cfg.LockResouceKey,
+		Key:      cfg.LockResourceKey,
 		Owner:    cfg.UUID,
 		TypeCode: locketmodels.LOCK,
 	}
@@ -223,7 +220,7 @@ func main() {
 	group := grouper.NewOrdered(os.Interrupt, members)
 	process := ifrit.Invoke(sigmon.New(group))
 
-	// This is used by testrunner to signal ready for tests.
+	// This is used by test_helpers to signal ready for tests.
 	logger.Info("started", lager.Data{"port": cfg.API.ListenPort})
 
 	errChan := process.Wait()
@@ -324,21 +321,21 @@ func apiHandler(cfg config.Config, uaaClient uaaclient.TokenValidator, database 
 	tcpMappingsHandler := handlers.NewTcpRouteMappingsHandler(uaaClient, validator, database, int(cfg.MaxTTL.Seconds()), logger)
 
 	actions := rata.Handlers{
-		routing_api.UpsertRoute:           route(routesHandler.Upsert),
-		routing_api.DeleteRoute:           route(routesHandler.Delete),
-		routing_api.ListRoute:             route(routesHandler.List),
-		routing_api.EventStreamRoute:      route(eventStreamHandler.EventStream),
-		routing_api.ListRouterGroups:      route(routerGroupsHandler.ListRouterGroups),
-		routing_api.CreateRouterGroup:     route(routerGroupsHandler.CreateRouterGroup),
-		routing_api.UpdateRouterGroup:     route(routerGroupsHandler.UpdateRouterGroup),
-		routing_api.DeleteRouterGroup:     route(routerGroupsHandler.DeleteRouterGroup),
-		routing_api.UpsertTcpRouteMapping: route(tcpMappingsHandler.Upsert),
-		routing_api.DeleteTcpRouteMapping: route(tcpMappingsHandler.Delete),
-		routing_api.ListTcpRouteMapping:   route(tcpMappingsHandler.List),
-		routing_api.EventStreamTcpRoute:   route(eventStreamHandler.TcpEventStream),
+		routingAPI.UpsertRoute:           route(routesHandler.Upsert),
+		routingAPI.DeleteRoute:           route(routesHandler.Delete),
+		routingAPI.ListRoute:             route(routesHandler.List),
+		routingAPI.EventStreamRoute:      route(eventStreamHandler.EventStream),
+		routingAPI.ListRouterGroups:      route(routerGroupsHandler.ListRouterGroups),
+		routingAPI.CreateRouterGroup:     route(routerGroupsHandler.CreateRouterGroup),
+		routingAPI.UpdateRouterGroup:     route(routerGroupsHandler.UpdateRouterGroup),
+		routingAPI.DeleteRouterGroup:     route(routerGroupsHandler.DeleteRouterGroup),
+		routingAPI.UpsertTcpRouteMapping: route(tcpMappingsHandler.Upsert),
+		routingAPI.DeleteTcpRouteMapping: route(tcpMappingsHandler.Delete),
+		routingAPI.ListTcpRouteMapping:   route(tcpMappingsHandler.List),
+		routingAPI.EventStreamTcpRoute:   route(eventStreamHandler.TcpEventStream),
 	}
 
-	handler, err := rata.NewRouter(routing_api.Routes(), actions)
+	handler, err := rata.NewRouter(routingAPI.Routes(), actions)
 	if err != nil {
 		logger.Error("failed to create router", err)
 		os.Exit(1)

--- a/cmd/routing-api/routing_api_suite_test.go
+++ b/cmd/routing-api/routing_api_suite_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"crypto/tls"
 	"encoding/pem"
 	"fmt"
@@ -14,9 +15,7 @@ import (
 	tlsHelpers "code.cloudfoundry.org/cf-routing-test-helpers/tls"
 	locketrunner "code.cloudfoundry.org/locket/cmd/locket/testrunner"
 	routingAPI "code.cloudfoundry.org/routing-api"
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/config"
-	"code.cloudfoundry.org/routing-api/test_helpers"
 	"github.com/tedsuo/ifrit"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,7 +26,7 @@ import (
 )
 
 var (
-	defaultConfig         testrunner.RoutingAPITestConfig
+	defaultConfig         testHelpers.RoutingAPITestConfig
 	client                routingAPI.Client
 	locketBinPath         string
 	routingAPIBinPath     string
@@ -39,7 +38,7 @@ var (
 	locketPort            uint16
 	locketProcess         ifrit.Process
 	databaseName          string
-	dbAllocator           testrunner.DbAllocator
+	dbAllocator           testHelpers.DbAllocator
 	sqlDBConfig           *config.SqlDB
 	uaaCACertsPath        string
 	mTLSAPIServerKeyPath  string
@@ -72,7 +71,7 @@ var _ = SynchronizedBeforeSuite(
 
 		SetDefaultEventuallyTimeout(15 * time.Second)
 
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 
 		var err error
 		sqlDBConfig, err = dbAllocator.Create()
@@ -98,7 +97,7 @@ var _ = SynchronizedBeforeSuite(
 
 		apiCAPath, mTLSAPIServerCertPath, mTLSAPIServerKeyPath, mTLSAPIClientCert = tlsHelpers.GenerateCaAndMutualTlsCerts()
 
-		oAuthServer, oAuthServerPort = testrunner.SetupOauthServer(uaaServerCert)
+		oAuthServer, oAuthServerPort = testHelpers.SetupOauthServer(uaaServerCert)
 	},
 )
 
@@ -115,15 +114,15 @@ var _ = SynchronizedAfterSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	routingAPIPort = uint16(test_helpers.NextAvailPort())
-	routingAPIMTLSPort = uint16(test_helpers.NextAvailPort())
+	routingAPIPort = uint16(testHelpers.NextAvailPort())
+	routingAPIMTLSPort = uint16(testHelpers.NextAvailPort())
 
-	client = testrunner.RoutingApiClientWithPort(routingAPIPort, testrunner.RoutingAPIIP)
+	client = testHelpers.RoutingApiClientWithPort(routingAPIPort, testHelpers.RoutingAPIIP)
 	err := dbAllocator.Reset()
 	Expect(err).NotTo(HaveOccurred())
 
-	locketPort = uint16(test_helpers.NextAvailPort())
-	locketProcess = testrunner.StartLocket(
+	locketPort = uint16(testHelpers.NextAvailPort())
+	locketProcess = testHelpers.StartLocket(
 		locketPort,
 		locketBinPath,
 		databaseName,
@@ -133,12 +132,12 @@ var _ = BeforeEach(func() {
 	oAuthServerPort, err := strconv.ParseInt(oAuthServerPort, 10, 0)
 	Expect(err).NotTo(HaveOccurred())
 
-	locketAddress := fmt.Sprintf("%s:%d", testrunner.Host, locketPort)
+	locketAddress := fmt.Sprintf("%s:%d", testHelpers.Host, locketPort)
 	locketConfig := locketrunner.ClientLocketConfig()
 	locketConfig.LocketAddress = locketAddress
 
-	routingAPIAdminPort = test_helpers.NextAvailPort()
-	defaultConfig = testrunner.GetRoutingAPITestConfig(
+	routingAPIAdminPort = testHelpers.NextAvailPort()
+	defaultConfig = testHelpers.GetRoutingAPITestConfig(
 		routingAPIPort,
 		routingAPIAdminPort,
 		routingAPIMTLSPort,
@@ -153,5 +152,5 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	testrunner.StopLocket(locketProcess)
+	testHelpers.StopLocket(locketProcess)
 })

--- a/cmd/routing-api/stats_test.go
+++ b/cmd/routing-api/stats_test.go
@@ -3,12 +3,12 @@ package main_test
 import (
 	"bufio"
 	"bytes"
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"fmt"
 	"net"
 	"os"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/models"
 	"github.com/tedsuo/ifrit"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
@@ -29,10 +29,10 @@ var _ = Describe("Routes API", func() {
 	)
 
 	BeforeEach(func() {
-		routingAPIConfig := testrunner.GetRoutingAPIConfig(defaultConfig)
-		configFilePath = testrunner.WriteConfigToTempFile(routingAPIConfig)
-		routingAPIRunner := testrunner.New(routingAPIBinPath, testrunner.Args{
-			IP:         testrunner.RoutingAPIIP,
+		routingAPIConfig := testHelpers.GetRoutingAPIConfig(defaultConfig)
+		configFilePath = testHelpers.WriteConfigToTempFile(routingAPIConfig)
+		routingAPIRunner := testHelpers.New(routingAPIBinPath, testHelpers.Args{
+			IP:         testHelpers.RoutingAPIIP,
 			ConfigPath: configFilePath,
 			DevMode:    true,
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"code.cloudfoundry.org/locket"
 	"code.cloudfoundry.org/routing-api/models"
@@ -78,7 +78,7 @@ type Config struct {
 	SkipSSLValidation               bool                      `yaml:"skip_ssl_validation"`
 	LockTTL                         time.Duration             `yaml:"lock_ttl"`
 	RetryInterval                   time.Duration             `yaml:"retry_interval"`
-	LockResouceKey                  string                    `yaml:"lock_resource_key"`
+	LockResourceKey                 string                    `yaml:"lock_resource_key"`
 }
 
 func NewConfigFromFile(configFile string, authDisabled bool) (Config, error) {
@@ -185,8 +185,8 @@ func (cfg *Config) process() error {
 		cfg.RetryInterval = locket.RetryInterval
 	}
 
-	if cfg.LockResouceKey == "" {
-		cfg.LockResouceKey = DefaultLockResourceKey
+	if cfg.LockResourceKey == "" {
+		cfg.LockResourceKey = DefaultLockResourceKey
 	}
 
 	cfg.SqlDB.SkipSSLValidation = cfg.SkipSSLValidation

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,8 +18,8 @@ var _ = Describe("Config", func() {
 		Context("when auth is enabled", func() {
 			Context("when the file exists", func() {
 				It("returns a valid Config struct", func() {
-					cfg_file := "../example_config/example.yml"
-					cfg, err := config.NewConfigFromFile(cfg_file, false)
+					cfgFile := "../example_config/example.yml"
+					cfg, err := config.NewConfigFromFile(cfgFile, false)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cfg.API.ListenPort).To(Equal(3000))
@@ -43,7 +43,7 @@ var _ = Describe("Config", func() {
 					Expect(cfg.SqlDB.MaxOpenConns).To(Equal(5))
 					Expect(cfg.SqlDB.ConnMaxLifetime).To(Equal(1200))
 					Expect(cfg.MaxTTL).To(Equal(2 * time.Minute))
-					Expect(cfg.LockResouceKey).To(Equal("my-key"))
+					Expect(cfg.LockResourceKey).To(Equal("my-key"))
 					Expect(cfg.LockTTL).To(Equal(10 * time.Second))
 					Expect(cfg.RetryInterval).To(Equal(5 * time.Second))
 					Expect(cfg.Locket.LocketAddress).To(Equal("http://localhost:5678"))
@@ -61,8 +61,8 @@ var _ = Describe("Config", func() {
 
 				Context("when there is no token endpoint specified", func() {
 					It("returns an error", func() {
-						cfg_file := "../example_config/missing_uaa_url.yml"
-						_, err := config.NewConfigFromFile(cfg_file, false)
+						cfgFile := "../example_config/missing_uaa_url.yml"
+						_, err := config.NewConfigFromFile(cfgFile, false)
 						Expect(err).To(HaveOccurred())
 					})
 				})
@@ -70,8 +70,8 @@ var _ = Describe("Config", func() {
 
 			Context("when the file does not exists", func() {
 				It("returns an error", func() {
-					cfg_file := "notexist"
-					_, err := config.NewConfigFromFile(cfg_file, false)
+					cfgFile := "notexist"
+					_, err := config.NewConfigFromFile(cfgFile, false)
 
 					Expect(err).To(HaveOccurred())
 				})
@@ -81,8 +81,8 @@ var _ = Describe("Config", func() {
 		Context("when auth is disabled", func() {
 			Context("when the file exists", func() {
 				It("returns a valid config", func() {
-					cfg_file := "../example_config/example.yml"
-					cfg, err := config.NewConfigFromFile(cfg_file, true)
+					cfgFile := "../example_config/example.yml"
+					cfg, err := config.NewConfigFromFile(cfgFile, true)
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cfg.LogGuid).To(Equal("my_logs"))
@@ -96,8 +96,8 @@ var _ = Describe("Config", func() {
 
 				Context("when there is no token endpoint url", func() {
 					It("returns a valid config", func() {
-						cfg_file := "../example_config/missing_uaa_url.yml"
-						cfg, err := config.NewConfigFromFile(cfg_file, true)
+						cfgFile := "../example_config/missing_uaa_url.yml"
+						cfg, err := config.NewConfigFromFile(cfgFile, true)
 
 						Expect(err).NotTo(HaveOccurred())
 						Expect(cfg.LogGuid).To(Equal("my_logs"))
@@ -253,7 +253,7 @@ var _ = Describe("Config", func() {
 			It("populates the default value for LockResourceKey", func() {
 				cfg, err := config.NewConfigFromBytes(testConfig, true)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.LockResouceKey).To(Equal(config.DefaultLockResourceKey))
+				Expect(cfg.LockResourceKey).To(Equal(config.DefaultLockResourceKey))
 			})
 
 			It("populates the default value for LockTTL from locket library", func() {

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -1386,7 +1386,7 @@ var _ = Describe("SqlDB", func() {
 			})
 
 			It("does not return an error when canceled", func() {
-				_, errors, cancel := sqlDB.WatchChanges(db.TCP_WATCH)
+				_, errors, cancel := sqlDB.WatchChanges(db.TcpWatch)
 				cancel()
 				Consistently(errors).ShouldNot(Receive())
 				Eventually(errors).Should(BeClosed())
@@ -1413,7 +1413,7 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				It("should return an update watch event", func() {
-					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.TcpWatch)
 
 					updatedTcpRoute := models.NewTcpRouteMapping(
 						tcpRoute.RouterGroupGuid,
@@ -1440,7 +1440,7 @@ var _ = Describe("SqlDB", func() {
 
 			Context("when a tcp route is created", func() {
 				It("should return an create watch event", func() {
-					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.TcpWatch)
 
 					tcpRoute := models.NewTcpRouteMapping(routerGroupId, 3057, "127.0.0.1", 2990, 2991, "instanceId", nil, 50, models.ModificationTag{})
 					err = sqlDB.SaveTcpRouteMapping(tcpRoute)
@@ -1460,7 +1460,7 @@ var _ = Describe("SqlDB", func() {
 					err := sqlDB.SaveTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
-					results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.TcpWatch)
 
 					err = sqlDB.DeleteTcpRouteMapping(tcpRoute)
 					Expect(err).NotTo(HaveOccurred())
@@ -1475,8 +1475,8 @@ var _ = Describe("SqlDB", func() {
 
 			Context("Cancel Watches", func() {
 				It("cancels any in-flight watches", func() {
-					results, err, _ := sqlDB.WatchChanges(db.TCP_WATCH)
-					results2, err2, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+					results, err, _ := sqlDB.WatchChanges(db.TcpWatch)
+					results2, err2, _ := sqlDB.WatchChanges(db.TcpWatch)
 
 					sqlDB.CancelWatches()
 
@@ -1494,7 +1494,7 @@ var _ = Describe("SqlDB", func() {
 				It("causes subsequent calls to WatchChanges to error", func() {
 					sqlDB.CancelWatches()
 
-					event, err, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+					event, err, _ := sqlDB.WatchChanges(db.TcpWatch)
 					Eventually(err).ShouldNot(Receive())
 					Eventually(err).Should(BeClosed())
 
@@ -1508,7 +1508,7 @@ var _ = Describe("SqlDB", func() {
 			var err error
 
 			It("does not return an error when canceled", func() {
-				_, errors, cancel := sqlDB.WatchChanges(db.HTTP_WATCH)
+				_, errors, cancel := sqlDB.WatchChanges(db.HttpWatch)
 				cancel()
 				Consistently(errors).ShouldNot(Receive())
 				Eventually(errors).Should(BeClosed())
@@ -1524,7 +1524,7 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				It("should return an update watch event", func() {
-					results, _, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.HttpWatch)
 
 					err = sqlDB.SaveRoute(httpRoute)
 					Expect(err).NotTo(HaveOccurred())
@@ -1539,7 +1539,7 @@ var _ = Describe("SqlDB", func() {
 
 			Context("when a http route is created", func() {
 				It("should return an create watch event", func() {
-					results, _, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.HttpWatch)
 
 					httpRoute := models.NewRoute("post_here", 7002, "127.0.0.1", "my-guid", "https://rs.com", 5)
 					err := sqlDB.SaveRoute(httpRoute)
@@ -1559,7 +1559,7 @@ var _ = Describe("SqlDB", func() {
 					err := sqlDB.SaveRoute(httpRoute)
 					Expect(err).NotTo(HaveOccurred())
 
-					results, _, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+					results, _, _ := sqlDB.WatchChanges(db.HttpWatch)
 
 					err = sqlDB.DeleteRoute(httpRoute)
 					Expect(err).NotTo(HaveOccurred())
@@ -1574,8 +1574,8 @@ var _ = Describe("SqlDB", func() {
 
 			Context("Cancel Watches", func() {
 				It("cancels any in-flight watches", func() {
-					results, err, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
-					results2, err2, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+					results, err, _ := sqlDB.WatchChanges(db.HttpWatch)
+					results2, err2, _ := sqlDB.WatchChanges(db.HttpWatch)
 
 					sqlDB.CancelWatches()
 
@@ -1588,7 +1588,7 @@ var _ = Describe("SqlDB", func() {
 				It("causes subsequent calls to WatchChanges to error", func() {
 					sqlDB.CancelWatches()
 
-					event, err, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+					event, err, _ := sqlDB.WatchChanges(db.HttpWatch)
 					Eventually(err).ShouldNot(Receive())
 					Eventually(err).Should(BeClosed())
 
@@ -1682,7 +1682,7 @@ var _ = Describe("SqlDB", func() {
 						})
 
 						It("should emit a ExpireEvent for the pruned route", func() {
-							results, _, _ := sqlDB.WatchChanges(db.TCP_WATCH)
+							results, _, _ := sqlDB.WatchChanges(db.TcpWatch)
 							var event db.Event
 							Eventually(results, 5).Should((Receive(&event)))
 							Expect(event).NotTo(BeNil())
@@ -1747,7 +1747,7 @@ var _ = Describe("SqlDB", func() {
 						})
 
 						It("should emit a ExpireEvent for the pruned route", func() {
-							results, _, _ := sqlDB.WatchChanges(db.HTTP_WATCH)
+							results, _, _ := sqlDB.WatchChanges(db.HttpWatch)
 							var event db.Event
 							Eventually(results, 5).Should((Receive(&event)))
 							Expect(event).NotTo(BeNil())

--- a/db/db_suite_test.go
+++ b/db/db_suite_test.go
@@ -1,9 +1,9 @@
 package db_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"testing"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/config"
 	_ "github.com/lib/pq"
 	. "github.com/onsi/ginkgo/v2"
@@ -12,18 +12,18 @@ import (
 
 var (
 	databaseCfg       *config.SqlDB
-	databaseAllocator testrunner.DbAllocator
+	databaseAllocator testHelpers.DbAllocator
 )
 
-func TestDB(t *testing.T) {
+func TestDB(test *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "DB Suite")
+	RunSpecs(test, "DB Suite")
 }
 
 var _ = BeforeSuite(func() {
 	var err error
 
-	databaseAllocator = testrunner.NewDbAllocator()
+	databaseAllocator = testHelpers.NewDbAllocator()
 	databaseCfg, err = databaseAllocator.Create()
 	Expect(err).ToNot(HaveOccurred(), "error occurred starting database client, is the database running?")
 })

--- a/db/mysql_connection_string_builder_test.go
+++ b/db/mysql_connection_string_builder_test.go
@@ -1,14 +1,13 @@
 package db_test
 
 import (
+	"code.cloudfoundry.org/routing-api/test_helpers"
 	"crypto/ecdsa"
 	"crypto/x509"
 
 	"code.cloudfoundry.org/routing-api/config"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/db/fakes"
-	"code.cloudfoundry.org/routing-api/test_helpers"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/handlers/event_stream_handler.go
+++ b/handlers/event_stream_handler.go
@@ -39,7 +39,7 @@ func (h *EventStreamHandler) EventStream(w http.ResponseWriter, req *http.Reques
 		}
 	}()
 	log := h.logger.Session("event-stream-handler")
-	h.handleEventStream(log, db.HTTP_WATCH, w, req)
+	h.handleEventStream(log, db.HttpWatch, w, req)
 }
 
 func (h *EventStreamHandler) TcpEventStream(w http.ResponseWriter, req *http.Request) {
@@ -54,7 +54,7 @@ func (h *EventStreamHandler) TcpEventStream(w http.ResponseWriter, req *http.Req
 		}
 	}()
 	log := h.logger.Session("tcp-event-stream-handler")
-	h.handleEventStream(log, db.TCP_WATCH, w, req)
+	h.handleEventStream(log, db.TcpWatch, w, req)
 }
 
 func (h *EventStreamHandler) handleEventStream(log lager.Logger, filterKey string,

--- a/handlers/event_stream_handler_test.go
+++ b/handlers/event_stream_handler_test.go
@@ -117,7 +117,7 @@ var _ = Describe("EventsHandler", func() {
 
 					Expect(event).To(Equal(expectedEvent))
 					filterString := database.WatchChangesArgsForCall(0)
-					Expect(filterString).To(Equal(db.HTTP_WATCH))
+					Expect(filterString).To(Equal(db.HttpWatch))
 				})
 
 				It("sets the content-type to text/event-stream", func() {
@@ -274,7 +274,7 @@ var _ = Describe("EventsHandler", func() {
 
 					Expect(event).To(Equal(expectedEvent))
 					filterString := database.WatchChangesArgsForCall(0)
-					Expect(filterString).To(Equal(db.TCP_WATCH))
+					Expect(filterString).To(Equal(db.TcpWatch))
 				})
 			})
 		})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -42,8 +42,8 @@ func NewMetricsReporter(database db.DB, stats PartialStatsdClient, ticker *time.
 }
 
 func (r *MetricsReporter) Run(signals <-chan os.Signal, ready chan<- struct{}) error {
-	httpEventChan, httpErrChan, _ := r.db.WatchChanges(db.HTTP_WATCH)
-	tcpEventChan, tcpErrChan, _ := r.db.WatchChanges(db.TCP_WATCH)
+	httpEventChan, httpErrChan, _ := r.db.WatchChanges(db.HttpWatch)
+	tcpEventChan, tcpErrChan, _ := r.db.WatchChanges(db.TcpWatch)
 	close(ready)
 	ready = nil
 

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Metrics", func() {
 			resultsChan = make(chan db.Event, 1)
 			tcpResultsChan = make(chan db.Event, 1)
 			database.WatchChangesStub = func(filter string) (<-chan db.Event, <-chan error, context.CancelFunc) {
-				if filter == db.HTTP_WATCH {
+				if filter == db.HttpWatch {
 					return resultsChan, nil, nil
 				} else {
 					return tcpResultsChan, nil, nil

--- a/migration/V0_init_migration_test.go
+++ b/migration/V0_init_migration_test.go
@@ -1,10 +1,10 @@
 package migration_test
 
 import (
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	"code.cloudfoundry.org/routing-api/models"
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,13 +12,13 @@ import (
 
 var _ = Describe("V0InitMigration", func() {
 	var (
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 		dbClient    db.Client
 		sqlDB       *db.SqlDB
 		err         error
 	)
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V2_update_rg_migration_test.go
+++ b/migration/V2_update_rg_migration_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"strings"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	"code.cloudfoundry.org/routing-api/models"
@@ -15,11 +15,11 @@ import (
 var _ = Describe("V2UpdateRgMigration", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V3_update_tcp_route_migration_test.go
+++ b/migration/V3_update_tcp_route_migration_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	"code.cloudfoundry.org/routing-api/models"
@@ -15,11 +15,11 @@ import (
 var _ = Describe("V3UpdateTcpRouteMigration", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V4_add_rg_uniq_idx_tcp_route_migration_test.go
+++ b/migration/V4_add_rg_uniq_idx_tcp_route_migration_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	v0 "code.cloudfoundry.org/routing-api/migration/v0"
@@ -16,11 +16,11 @@ import (
 var _ = Describe("V4AddRgUniqIdxTCPRouteMigration", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V5_sni_hostname_migration_test.go
+++ b/migration/V5_sni_hostname_migration_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	v0 "code.cloudfoundry.org/routing-api/migration/v0"
@@ -16,11 +16,11 @@ import (
 var _ = Describe("V5SniHostnameMigration", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V6_tls_tcp_route_test.go
+++ b/migration/V6_tls_tcp_route_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	v5 "code.cloudfoundry.org/routing-api/migration/v5"
@@ -16,11 +16,11 @@ import (
 var _ = Describe("V6TCPTLSRoutes", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/V7_instance_id_defaults_test.go
+++ b/migration/V7_instance_id_defaults_test.go
@@ -1,9 +1,9 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"time"
 
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	v6 "code.cloudfoundry.org/routing-api/migration/v6"
@@ -16,11 +16,11 @@ import (
 var _ = Describe("V7TCPTLSRoutes", func() {
 	var (
 		sqlDB       *db.SqlDB
-		dbAllocator testrunner.DbAllocator
+		dbAllocator testHelpers.DbAllocator
 	)
 
 	BeforeEach(func() {
-		dbAllocator = testrunner.NewDbAllocator()
+		dbAllocator = testHelpers.NewDbAllocator()
 		sqlCfg, err := dbAllocator.Create()
 		Expect(err).NotTo(HaveOccurred())
 

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -1,11 +1,11 @@
 package migration_test
 
 import (
+	testHelpers "code.cloudfoundry.org/routing-api/test_helpers"
 	"fmt"
 
 	"code.cloudfoundry.org/lager/v3"
 	"code.cloudfoundry.org/lager/v3/lagertest"
-	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
 	"code.cloudfoundry.org/routing-api/db"
 	"code.cloudfoundry.org/routing-api/migration"
 	"code.cloudfoundry.org/routing-api/migration/fakes"
@@ -16,7 +16,7 @@ import (
 var _ = Describe("Migration", func() {
 	var (
 		sqlDB                 *db.SqlDB
-		allocator             testrunner.DbAllocator
+		allocator             testHelpers.DbAllocator
 		fakeMigration         *fakes.FakeMigration
 		fakeLastMigration     *fakes.FakeMigration
 		migrations            []migration.Migration
@@ -243,7 +243,7 @@ var _ = Describe("Migration", func() {
 
 	Describe("Test Migrations", func() {
 		BeforeEach(func() {
-			allocator = testrunner.NewDbAllocator()
+			allocator = testHelpers.NewDbAllocator()
 			sqlCfg, err := allocator.Create()
 			Expect(err).ToNot(HaveOccurred())
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -426,7 +426,7 @@ var _ = Describe("Models", func() {
 		BeforeEach(func() {
 			tag, err := NewModificationTag()
 			Expect(err).ToNot(HaveOccurred())
-			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag)
+			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointerToString("sni-hostname"), 66, tag)
 		})
 
 		Describe("SetDefaults", func() {

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -75,7 +75,13 @@ func NewTcpRouteMapping(
 }
 
 func (m TcpRouteMapping) String() string {
-	return fmt.Sprintf("%s:%d<->%s:%d", m.RouterGroupGuid, m.ExternalPort, m.HostIP, m.HostPort)
+	return fmt.Sprintf(
+		"%s:%d<->%s:%d",
+		m.RouterGroupGuid,
+		m.ExternalPort,
+		m.HostIP,
+		m.HostPort,
+	)
 }
 
 func (m TcpRouteMapping) Matches(other TcpRouteMapping) bool {
@@ -106,11 +112,11 @@ func (m TcpRouteMapping) Matches(other TcpRouteMapping) bool {
 		sameSniHostname
 }
 
-func (t *TcpRouteMapping) SetDefaults(maxTTL int) {
+func (m *TcpRouteMapping) SetDefaults(maxTTL int) {
 	// default ttl if not present
 	// TTL is a pointer to a uint16 so that we can
 	// detect if it's present or not (i.e. nil or 0)
-	if t.TTL == nil {
-		t.TTL = &maxTTL
+	if m.TTL == nil {
+		m.TTL = &maxTTL
 	}
 }

--- a/models/tcp_route_test.go
+++ b/models/tcp_route_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func pointertoString(s string) *string { return &s }
+func pointerToString(s string) *string { return &s }
 
 var _ = Describe("TCP Route", func() {
 	Describe("TcpMappingEntity", func() {
@@ -36,7 +36,7 @@ var _ = Describe("TCP Route", func() {
 
 			Context("when a valid SNI hostname is provided", func() {
 				BeforeEach(func() {
-					sniHostNamePtr = pointertoString("sniHostname")
+					sniHostNamePtr = pointerToString("sniHostname")
 				})
 
 				It("Accepts the value", func() {
@@ -50,7 +50,7 @@ var _ = Describe("TCP Route", func() {
 			})
 			Context("when the SNI hostname is empty", func() {
 				BeforeEach(func() {
-					sniHostNamePtr = pointertoString("")
+					sniHostNamePtr = pointerToString("")
 				})
 				It("is provided in the marshaled JSON", func() {
 					j, err := json.Marshal(tcpRouteMapping)
@@ -64,7 +64,7 @@ var _ = Describe("TCP Route", func() {
 			var sniHostNamePtr2 *string
 
 			BeforeEach(func() {
-				sniHostNamePtr = pointertoString("sniHostName")
+				sniHostNamePtr = pointerToString("sniHostName")
 			})
 
 			JustBeforeEach(func() {
@@ -81,7 +81,7 @@ var _ = Describe("TCP Route", func() {
 			})
 			Context("when two routes have equal values", func() {
 				BeforeEach(func() {
-					sniHostNamePtr2 = pointertoString("sniHostName")
+					sniHostNamePtr2 = pointerToString("sniHostName")
 				})
 				It("matches", func() {
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
@@ -90,7 +90,7 @@ var _ = Describe("TCP Route", func() {
 
 			Context("when two routes have values that are not equal", func() {
 				BeforeEach(func() {
-					sniHostNamePtr2 = pointertoString("sniHostName2")
+					sniHostNamePtr2 = pointerToString("sniHostName2")
 				})
 				It("doesn't match", func() {
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeFalse())

--- a/test_helpers/certificates.go
+++ b/test_helpers/certificates.go
@@ -23,7 +23,7 @@ const (
 )
 
 func CreateCA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	caPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate key: %s", err)
 	}
@@ -33,7 +33,7 @@ func CreateCA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 		return nil, nil, fmt.Errorf("create cert template: %s", err)
 	}
 
-	caDER, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &caPriv.PublicKey, caPriv)
+	caDER, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating certificate: %s", err)
 	}
@@ -43,15 +43,15 @@ func CreateCA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 		return nil, nil, fmt.Errorf("parsing ca cert: %s", err)
 	}
 
-	return caCert, caPriv, nil
+	return caCert, privateKey, nil
 }
 
-func CreateCertificate(rootCert *x509.Certificate, caPriv *ecdsa.PrivateKey, certType CertType) (tls.Certificate, error) {
-	return createCertificateWithTime(rootCert, caPriv, certType, time.Now(), time.Now().AddDate(10, 0, 0))
+func CreateCertificate(rootCert *x509.Certificate, privateKey *ecdsa.PrivateKey, certType CertType) (tls.Certificate, error) {
+	return createCertificateWithTime(rootCert, privateKey, certType, time.Now(), time.Now().AddDate(10, 0, 0))
 }
 
-func CreateExpiredCertificate(rootCert *x509.Certificate, caPriv *ecdsa.PrivateKey, certType CertType) (tls.Certificate, error) {
-	return createCertificateWithTime(rootCert, caPriv, certType, time.Now().AddDate(-1, 0, 0), time.Now().Add(time.Second*-1))
+func CreateExpiredCertificate(rootCert *x509.Certificate, privateKey *ecdsa.PrivateKey, certType CertType) (tls.Certificate, error) {
+	return createCertificateWithTime(rootCert, privateKey, certType, time.Now().AddDate(-1, 0, 0), time.Now().Add(time.Second*-1))
 }
 
 func createCertificateWithTime(rootCert *x509.Certificate, caPriv *ecdsa.PrivateKey, certType CertType, notBefore, notAfter time.Time) (tls.Certificate, error) {

--- a/test_helpers/constants.go
+++ b/test_helpers/constants.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"code.cloudfoundry.org/routing-api/config"

--- a/test_helpers/db.go
+++ b/test_helpers/db.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"database/sql"

--- a/test_helpers/helpers.go
+++ b/test_helpers/helpers.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"code.cloudfoundry.org/routing-api/config"

--- a/test_helpers/locket.go
+++ b/test_helpers/locket.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"code.cloudfoundry.org/locket/cmd/locket/config"

--- a/test_helpers/ports.go
+++ b/test_helpers/ports.go
@@ -1,9 +1,8 @@
 package test_helpers
 
 import (
-	"sync"
-
 	. "github.com/onsi/ginkgo/v2"
+	"sync"
 )
 
 var (

--- a/test_helpers/routing_api.go
+++ b/test_helpers/routing_api.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"code.cloudfoundry.org/locket"

--- a/test_helpers/runner.go
+++ b/test_helpers/runner.go
@@ -1,4 +1,4 @@
-package testrunner
+package test_helpers
 
 import (
 	"fmt"
@@ -12,9 +12,8 @@ import (
 	"code.cloudfoundry.org/locket/cmd/locket/testrunner"
 	"code.cloudfoundry.org/routing-api/config"
 	"code.cloudfoundry.org/routing-api/models"
-	"code.cloudfoundry.org/routing-api/test_helpers"
 	ginkgomon "github.com/tedsuo/ifrit/ginkgomon_v2"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type Args struct {
@@ -103,7 +102,7 @@ func createConfig(
 	mtlsServerCertPath string,
 	mtlsServerKeyPath string,
 ) (string, error) {
-	adminPort := test_helpers.NextAvailPort()
+	adminPort := NextAvailPort()
 	locketConfig := testrunner.ClientLocketConfig()
 
 	routingAPIConfig := config.Config{


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
This PR moves test fixtures being used in multiple places into one package. It also fixes a spelling mistake for a struct member, remove unused constants, and converts underscore cased variables to camel cased variables to adhere to Go styling


Backward Compatibility
---------------
Breaking Change? **No**