### PR TITLE
Update routing-api's db logic to search  for existing records using all unique fields of a tcproutemappingentity

### DIFF
--- a/cmd/routing-api/api_test.go
+++ b/cmd/routing-api/api_test.go
@@ -379,6 +379,7 @@ var _ = Describe("Routes API", func() {
 								ExternalPort:     52000,
 								HostIP:           "1.2.3.4",
 								HostPort:         60000,
+								HostTLSPort:      60001,
 								TTL:              &maxTTL,
 								IsolationSegment: "some-iso-seg",
 							}}

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -13,6 +13,11 @@ type TcpRouteMapping struct {
 	TcpMappingEntity
 }
 
+// IMPORTANT!! when adding a new field here that is part of the unique index for
+//
+//	a tcp route, make sure to update not only the logic for Matches(),
+//	but also the SqlDb.FindExistingTcpRouteMapping() function's custom
+//	WHERE filter to include the new field
 type TcpMappingEntity struct {
 	RouterGroupGuid string  `gorm:"not null; unique_index:idx_tcp_route" json:"router_group_guid"`
 	HostPort        uint16  `gorm:"not null; unique_index:idx_tcp_route; type:int" json:"backend_port"`


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Previously it searched all but sni_hostname + host_tls_port, which means there were bugs with apps on the same hostIP, both with 0 as the host_port, but differing host_tls_ports.

Theoretically this is also a bug for SNI routes, which would result in problems if there was a case where a given backend had a routes to the same external port where one of them had an SNI hostname defined, and the other did not. This seems very unlikely (maybe impossible?) to have occurred in the real world though.

Added tests to ensure that every unique field in the tcproutemappingentity is accounted for when searching for existing records.



Backward Compatibility
---------------
Breaking Change? no