### PR TITLE
Use golang/protobuf instead of gogo/protobuf

### DIFF
--- a/cmd/routing-api/locket_test.go
+++ b/cmd/routing-api/locket_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Locket", func() {
 					Key:      "routing_api_lock",
 					Owner:    "Your worst enemy.",
 					Value:    "Something",
-					TypeCode: locketmodels.LOCK,
+					TypeCode: locketmodels.TypeCode_LOCK,
 				}
 
 				clock := clock.NewClock()

--- a/cmd/routing-api/main.go
+++ b/cmd/routing-api/main.go
@@ -126,7 +126,7 @@ func main() {
 	lockIdentifier := &locketmodels.Resource{
 		Key:      cfg.LockResouceKey,
 		Owner:    cfg.UUID,
-		TypeCode: locketmodels.LOCK,
+		TypeCode: locketmodels.TypeCode_LOCK,
 	}
 
 	locks = append(locks, grouper.Member{Name: "sql-lock", Runner: lock.NewLockRunner(


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
[gogo/protobuf](https://github.com/gogo/protobuf) has been deprecated for years.  We should be using up-to-date protobufs provided by [google.golang.org/protobuf](https://github.com/protocolbuffers/protobuf-go).  In order to fit our use cases, a protobuf plugin (`protoc-gen-go-bbs`) has been created to catch any customizations we want to add.


Backward Compatibility
---------------
Breaking Change? **No**
