### PR TITLE
Add config validator

### DIFF
--- a/cmd/config-validator/main.go
+++ b/cmd/config-validator/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"code.cloudfoundry.org/routing-api/config"
+)
+
+var (
+	configFile string
+	devMode    bool
+)
+
+func main() {
+	flag.StringVar(&configFile, "config", "", "Configuration File")
+	flag.BoolVar(&devMode, "devMode", false, "Disable authentication for easier development iteration")
+	flag.Parse()
+
+	_, err := config.NewConfigFromFile(configFile, devMode)
+	if err != nil {
+		log.Fatal("failed-to-load-config: ", err)
+	}
+	log.Print("config-loaded-successfully")
+}


### PR DESCRIPTION
- [X] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
Add config validator to routing-api so that we can validate config only in the routing-release pre-start.


Backward Compatibility
---------------
Breaking Change? **No**
