### PR TITLE
refactor(migration): Isolate migration models into versioned packages

### DIFF
--- a/migration/v6/model.go
+++ b/migration/v6/model.go
@@ -1,4 +1,4 @@
-package models
+package v6
 
 import "time"
 

--- a/migration/v6/models_suite_test.go
+++ b/migration/v6/models_suite_test.go
@@ -1,4 +1,4 @@
-package models_test
+package v6_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/migration/v6/models_test.go
+++ b/migration/v6/models_test.go
@@ -1,9 +1,9 @@
-package models_test
+package v6_test
 
 import (
 	"encoding/json"
 
-	. "code.cloudfoundry.org/routing-api/models"
+	. "code.cloudfoundry.org/routing-api/migration/v6"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/migration/v6/route.go
+++ b/migration/v6/route.go
@@ -1,4 +1,4 @@
-package models
+package v6
 
 import (
 	"time"

--- a/migration/v6/router_groups.go
+++ b/migration/v6/router_groups.go
@@ -1,4 +1,4 @@
-package models
+package v6
 
 import (
 	"errors"

--- a/migration/v6/tcp_route.go
+++ b/migration/v6/tcp_route.go
@@ -1,4 +1,4 @@
-package models
+package v6
 
 import (
 	"fmt"

--- a/migration/v6/tcp_route_test.go
+++ b/migration/v6/tcp_route_test.go
@@ -1,9 +1,9 @@
-package models_test
+package v6_test
 
 import (
 	"encoding/json"
 
-	"code.cloudfoundry.org/routing-api/models"
+	models "code.cloudfoundry.org/routing-api/migration/v6"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/migration/v7/model.go
+++ b/migration/v7/model.go
@@ -1,4 +1,4 @@
-package models
+package v7
 
 import "time"
 

--- a/migration/v7/models_suite_test.go
+++ b/migration/v7/models_suite_test.go
@@ -1,4 +1,4 @@
-package models_test
+package v7_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/migration/v7/models_test.go
+++ b/migration/v7/models_test.go
@@ -1,9 +1,9 @@
-package models_test
+package v7_test
 
 import (
 	"encoding/json"
 
-	. "code.cloudfoundry.org/routing-api/models"
+	. "code.cloudfoundry.org/routing-api/migration/v7"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/migration/v7/route.go
+++ b/migration/v7/route.go
@@ -1,4 +1,4 @@
-package models
+package v7
 
 import (
 	"time"

--- a/migration/v7/router_groups.go
+++ b/migration/v7/router_groups.go
@@ -1,4 +1,4 @@
-package models
+package v7
 
 import (
 	"errors"

--- a/migration/v7/tcp_route.go
+++ b/migration/v7/tcp_route.go
@@ -1,4 +1,4 @@
-package models
+package v7
 
 import (
 	"fmt"

--- a/migration/v7/tcp_route_test.go
+++ b/migration/v7/tcp_route_test.go
@@ -1,9 +1,9 @@
-package models_test
+package v7_test
 
 import (
 	"encoding/json"
 
-	"code.cloudfoundry.org/routing-api/models"
+	models "code.cloudfoundry.org/routing-api/migration/v7"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
This change improves code organization and prevents package name collisions between different migration versions by ensuring that each migration's models are self-contained.

The following changes were made:
- Renamed the package in `migration/v6` from `models` to `v6`.
- Renamed the package in `migration/v7` from `models` to `v7`.
- Updated all associated test files and import paths to reflect the package structure.

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
