### PR TITLE
feat: Add TLS termination and ALPN support for TCP route mappings

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -149,8 +149,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{}, true, "alpn1,alpn2")
 		})
 
 		JustBeforeEach(func() {
@@ -357,8 +357,8 @@ var _ = Describe("Client", func() {
 			tcpRouteMapping2 models.TcpRouteMapping
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{}, false, "")
 		})
 		JustBeforeEach(func() {
 			err = client.DeleteTcpRouteMappings([]models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2})
@@ -531,8 +531,8 @@ var _ = Describe("Client", func() {
 			data             []byte
 		)
 		BeforeEach(func() {
-			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{})
+			tcpRouteMapping1 = models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+			tcpRouteMapping2 = models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "", nil, 60, models.ModificationTag{}, true, "alpn1,alpn2")
 		})
 
 		Context("when the server returns a valid response", func() {
@@ -1118,7 +1118,7 @@ var _ = Describe("Client", func() {
 		)
 
 		BeforeEach(func() {
-			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60002, "", nil, 60, models.ModificationTag{})
+			tcpRoute1 = models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "alpn1,alpn2")
 
 			data, _ := json.Marshal(tcpRoute1)
 			event = sse.Event{

--- a/cmd/routing-api/api_test.go
+++ b/cmd/routing-api/api_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Routes API", func() {
 			BeforeEach(func() {
 				routerGroupGuid = getRouterGroupGuid()
 
-				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 60, models.ModificationTag{})
+				route1 = models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 60, models.ModificationTag{}, false, "")
 				eventStream, err = client.SubscribeToTcpEvents()
 				Expect(err).NotTo(HaveOccurred())
 			})
@@ -71,7 +71,7 @@ var _ = Describe("Routes API", func() {
 				done := make(chan interface{})
 				go func() {
 					defer close(done)
-					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 75, models.ModificationTag{})
+					routeUpdated := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 75, models.ModificationTag{}, false, "")
 
 					routesToInsert := []models.TcpRouteMapping{route1}
 
@@ -119,7 +119,7 @@ var _ = Describe("Routes API", func() {
 			})
 
 			It("gets events for expired routes", func() {
-				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 1, models.ModificationTag{})
+				routeExpire := models.NewTcpRouteMapping(routerGroupGuid, 3000, "1.1.1.1", 1234, 1235, "", nil, 1, models.ModificationTag{}, false, "")
 
 				err := client.UpsertTcpRouteMappings([]models.TcpRouteMapping{routeExpire})
 				Expect(err).NotTo(HaveOccurred())
@@ -341,8 +341,8 @@ var _ = Describe("Routes API", func() {
 			Context("POST", func() {
 				It("allows to create given tcp route mappings", func() {
 					var err error
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{}, true, "alpn1,alpn2")
 
 					tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -358,7 +358,7 @@ var _ = Describe("Routes API", func() {
 				Context("when tcp route mappings already exist", func() {
 					BeforeEach(func() {
 						var err error
-						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60001, "", nil, 60, models.ModificationTag{})
+						tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60001, "", nil, 60, models.ModificationTag{}, true, "alpn1,alpn2")
 
 						tcpRouteMappings := []models.TcpRouteMapping{tcpRouteMapping1}
 						err = client.UpsertTcpRouteMappings(tcpRouteMappings)
@@ -407,8 +407,8 @@ var _ = Describe("Routes API", func() {
 				})
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{}, true, "alpn1,alpn2")
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err = client.UpsertTcpRouteMappings(tcpRouteMappings)
 
@@ -433,8 +433,8 @@ var _ = Describe("Routes API", func() {
 				)
 
 				JustBeforeEach(func() {
-					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{})
-					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{})
+					tcpRouteMapping1 = models.NewTcpRouteMapping(routerGroupGuid, 52000, "1.2.3.4", 60000, 60002, "", nil, 60, models.ModificationTag{}, false, "")
+					tcpRouteMapping2 = models.NewTcpRouteMapping(routerGroupGuid, 52001, "1.2.3.5", 60001, 60003, "", nil, 3, models.ModificationTag{}, true, "alpn1,alpn2")
 					tcpRouteMappings = []models.TcpRouteMapping{tcpRouteMapping1, tcpRouteMapping2}
 					err := client.UpsertTcpRouteMappings(tcpRouteMappings)
 

--- a/db/db_sql_test.go
+++ b/db/db_sql_test.go
@@ -1955,12 +1955,14 @@ var _ = Describe("SqlDB", func() {
 				})
 
 				It("eventually resolves the issue", func() {
-					Eventually(logger, 2).Should(gbytes.Say(`"prune.successfully-finished-pruning-tcp-routes","log_level":1,"data":{"rowsAffected":1}`))
-					Eventually(logger, 2).Should(gbytes.Say(`"prune.successfully-finished-pruning-http-routes","log_level":1,"data":{"rowsAffected":1}`))
-					Eventually(logger, 2).Should(gbytes.Say(`failed-to-prune-tcp-routes","log_level":2,"data":{"error":"temp-error"}`))
-					Eventually(logger, 2).Should(gbytes.Say(`failed-to-prune-http-routes","log_level":2,"data":{"error":"temp-error"}`))
-					Eventually(logger, 2).Should(gbytes.Say(`"prune.successfully-finished-pruning-tcp-routes","log_level":1,"data":{"rowsAffected":111}`))
-					Eventually(logger, 2).Should(gbytes.Say(`"prune.successfully-finished-pruning-http-routes","log_level":1,"data":{"rowsAffected":111}`))
+					timeout := 2.5
+
+					Eventually(logger, timeout).Should(gbytes.Say(`"prune.successfully-finished-pruning-tcp-routes","log_level":1,"data":{"rowsAffected":1}`))
+					Eventually(logger, timeout).Should(gbytes.Say(`"prune.successfully-finished-pruning-http-routes","log_level":1,"data":{"rowsAffected":1}`))
+					Eventually(logger, timeout).Should(gbytes.Say(`failed-to-prune-tcp-routes","log_level":2,"data":{"error":"temp-error"}`))
+					Eventually(logger, timeout).Should(gbytes.Say(`failed-to-prune-http-routes","log_level":2,"data":{"error":"temp-error"}`))
+					Eventually(logger, timeout).Should(gbytes.Say(`"prune.successfully-finished-pruning-tcp-routes","log_level":1,"data":{"rowsAffected":111}`))
+					Eventually(logger, timeout).Should(gbytes.Say(`"prune.successfully-finished-pruning-http-routes","log_level":1,"data":{"rowsAffected":111}`))
 				})
 			})
 		})

--- a/db/fakes/fake_db.go
+++ b/db/fakes/fake_db.go
@@ -47,6 +47,20 @@ type FakeDB struct {
 	deleteTcpRouteMappingReturnsOnCall map[int]struct {
 		result1 error
 	}
+	FindSimilarTcpRouteMappingsStub        func(string, uint16) ([]models.TcpRouteMapping, error)
+	findSimilarTcpRouteMappingsMutex       sync.RWMutex
+	findSimilarTcpRouteMappingsArgsForCall []struct {
+		arg1 string
+		arg2 uint16
+	}
+	findSimilarTcpRouteMappingsReturns struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}
+	findSimilarTcpRouteMappingsReturnsOnCall map[int]struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}
 	LockRouterGroupReadsStub        func()
 	lockRouterGroupReadsMutex       sync.RWMutex
 	lockRouterGroupReadsArgsForCall []struct {
@@ -396,6 +410,71 @@ func (fake *FakeDB) DeleteTcpRouteMappingReturnsOnCall(i int, result1 error) {
 	fake.deleteTcpRouteMappingReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappings(arg1 string, arg2 uint16) ([]models.TcpRouteMapping, error) {
+	fake.findSimilarTcpRouteMappingsMutex.Lock()
+	ret, specificReturn := fake.findSimilarTcpRouteMappingsReturnsOnCall[len(fake.findSimilarTcpRouteMappingsArgsForCall)]
+	fake.findSimilarTcpRouteMappingsArgsForCall = append(fake.findSimilarTcpRouteMappingsArgsForCall, struct {
+		arg1 string
+		arg2 uint16
+	}{arg1, arg2})
+	stub := fake.FindSimilarTcpRouteMappingsStub
+	fakeReturns := fake.findSimilarTcpRouteMappingsReturns
+	fake.recordInvocation("FindSimilarTcpRouteMappings", []interface{}{arg1, arg2})
+	fake.findSimilarTcpRouteMappingsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappingsCallCount() int {
+	fake.findSimilarTcpRouteMappingsMutex.RLock()
+	defer fake.findSimilarTcpRouteMappingsMutex.RUnlock()
+	return len(fake.findSimilarTcpRouteMappingsArgsForCall)
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappingsCalls(stub func(string, uint16) ([]models.TcpRouteMapping, error)) {
+	fake.findSimilarTcpRouteMappingsMutex.Lock()
+	defer fake.findSimilarTcpRouteMappingsMutex.Unlock()
+	fake.FindSimilarTcpRouteMappingsStub = stub
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappingsArgsForCall(i int) (string, uint16) {
+	fake.findSimilarTcpRouteMappingsMutex.RLock()
+	defer fake.findSimilarTcpRouteMappingsMutex.RUnlock()
+	argsForCall := fake.findSimilarTcpRouteMappingsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappingsReturns(result1 []models.TcpRouteMapping, result2 error) {
+	fake.findSimilarTcpRouteMappingsMutex.Lock()
+	defer fake.findSimilarTcpRouteMappingsMutex.Unlock()
+	fake.FindSimilarTcpRouteMappingsStub = nil
+	fake.findSimilarTcpRouteMappingsReturns = struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeDB) FindSimilarTcpRouteMappingsReturnsOnCall(i int, result1 []models.TcpRouteMapping, result2 error) {
+	fake.findSimilarTcpRouteMappingsMutex.Lock()
+	defer fake.findSimilarTcpRouteMappingsMutex.Unlock()
+	fake.FindSimilarTcpRouteMappingsStub = nil
+	if fake.findSimilarTcpRouteMappingsReturnsOnCall == nil {
+		fake.findSimilarTcpRouteMappingsReturnsOnCall = make(map[int]struct {
+			result1 []models.TcpRouteMapping
+			result2 error
+		})
+	}
+	fake.findSimilarTcpRouteMappingsReturnsOnCall[i] = struct {
+		result1 []models.TcpRouteMapping
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeDB) LockRouterGroupReads() {
@@ -1121,6 +1200,8 @@ func (fake *FakeDB) Invocations() map[string][][]interface{} {
 	defer fake.deleteRouterGroupMutex.RUnlock()
 	fake.deleteTcpRouteMappingMutex.RLock()
 	defer fake.deleteTcpRouteMappingMutex.RUnlock()
+	fake.findSimilarTcpRouteMappingsMutex.RLock()
+	defer fake.findSimilarTcpRouteMappingsMutex.RUnlock()
 	fake.lockRouterGroupReadsMutex.RLock()
 	defer fake.lockRouterGroupReadsMutex.RUnlock()
 	fake.lockRouterGroupWritesMutex.RLock()

--- a/event_source_test.go
+++ b/event_source_test.go
@@ -175,7 +175,7 @@ var _ = Describe("EventSource", func() {
 							Guid:  "my-guid",
 							Index: 5,
 						}
-						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60001, "instance-id", nil, 5, modTag)
+						tcpMapping := models.NewTcpRouteMapping("rguid1", 52000, "1.1.1.1", 60000, 60001, "instance-id", nil, 5, modTag, false, "")
 						tcpMapping.TTL = nil
 
 						expectedEvent := routing_api.TcpEvent{

--- a/handlers/fakes/fake_validator.go
+++ b/handlers/fakes/fake_validator.go
@@ -22,17 +22,31 @@ type FakeRouteValidator struct {
 	validateCreateReturnsOnCall map[int]struct {
 		result1 *routing_api.Error
 	}
-	ValidateCreateTcpRouteMappingStub        func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error
+	ValidateCreateTcpRouteMappingStub        func(models.TcpRouteMapping, []models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error
 	validateCreateTcpRouteMappingMutex       sync.RWMutex
 	validateCreateTcpRouteMappingArgsForCall []struct {
-		arg1 []models.TcpRouteMapping
-		arg2 models.RouterGroups
-		arg3 int
+		arg1 models.TcpRouteMapping
+		arg2 []models.TcpRouteMapping
+		arg3 models.RouterGroups
+		arg4 int
 	}
 	validateCreateTcpRouteMappingReturns struct {
 		result1 *routing_api.Error
 	}
 	validateCreateTcpRouteMappingReturnsOnCall map[int]struct {
+		result1 *routing_api.Error
+	}
+	ValidateCreateTcpRouteMappingsStub        func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error
+	validateCreateTcpRouteMappingsMutex       sync.RWMutex
+	validateCreateTcpRouteMappingsArgsForCall []struct {
+		arg1 []models.TcpRouteMapping
+		arg2 models.RouterGroups
+		arg3 int
+	}
+	validateCreateTcpRouteMappingsReturns struct {
+		result1 *routing_api.Error
+	}
+	validateCreateTcpRouteMappingsReturnsOnCall map[int]struct {
 		result1 *routing_api.Error
 	}
 	ValidateDeleteStub        func([]models.Route) *routing_api.Error
@@ -128,25 +142,26 @@ func (fake *FakeRouteValidator) ValidateCreateReturnsOnCall(i int, result1 *rout
 	}{result1}
 }
 
-func (fake *FakeRouteValidator) ValidateCreateTcpRouteMapping(arg1 []models.TcpRouteMapping, arg2 models.RouterGroups, arg3 int) *routing_api.Error {
-	var arg1Copy []models.TcpRouteMapping
-	if arg1 != nil {
-		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
-		copy(arg1Copy, arg1)
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMapping(arg1 models.TcpRouteMapping, arg2 []models.TcpRouteMapping, arg3 models.RouterGroups, arg4 int) *routing_api.Error {
+	var arg2Copy []models.TcpRouteMapping
+	if arg2 != nil {
+		arg2Copy = make([]models.TcpRouteMapping, len(arg2))
+		copy(arg2Copy, arg2)
 	}
 	fake.validateCreateTcpRouteMappingMutex.Lock()
 	ret, specificReturn := fake.validateCreateTcpRouteMappingReturnsOnCall[len(fake.validateCreateTcpRouteMappingArgsForCall)]
 	fake.validateCreateTcpRouteMappingArgsForCall = append(fake.validateCreateTcpRouteMappingArgsForCall, struct {
-		arg1 []models.TcpRouteMapping
-		arg2 models.RouterGroups
-		arg3 int
-	}{arg1Copy, arg2, arg3})
+		arg1 models.TcpRouteMapping
+		arg2 []models.TcpRouteMapping
+		arg3 models.RouterGroups
+		arg4 int
+	}{arg1, arg2Copy, arg3, arg4})
 	stub := fake.ValidateCreateTcpRouteMappingStub
 	fakeReturns := fake.validateCreateTcpRouteMappingReturns
-	fake.recordInvocation("ValidateCreateTcpRouteMapping", []interface{}{arg1Copy, arg2, arg3})
+	fake.recordInvocation("ValidateCreateTcpRouteMapping", []interface{}{arg1, arg2Copy, arg3, arg4})
 	fake.validateCreateTcpRouteMappingMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -160,17 +175,17 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCallCount() int {
 	return len(fake.validateCreateTcpRouteMappingArgsForCall)
 }
 
-func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCalls(stub func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error) {
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingCalls(stub func(models.TcpRouteMapping, []models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error) {
 	fake.validateCreateTcpRouteMappingMutex.Lock()
 	defer fake.validateCreateTcpRouteMappingMutex.Unlock()
 	fake.ValidateCreateTcpRouteMappingStub = stub
 }
 
-func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingArgsForCall(i int) ([]models.TcpRouteMapping, models.RouterGroups, int) {
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingArgsForCall(i int) (models.TcpRouteMapping, []models.TcpRouteMapping, models.RouterGroups, int) {
 	fake.validateCreateTcpRouteMappingMutex.RLock()
 	defer fake.validateCreateTcpRouteMappingMutex.RUnlock()
 	argsForCall := fake.validateCreateTcpRouteMappingArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturns(result1 *routing_api.Error) {
@@ -192,6 +207,74 @@ func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingReturnsOnCall(i int
 		})
 	}
 	fake.validateCreateTcpRouteMappingReturnsOnCall[i] = struct {
+		result1 *routing_api.Error
+	}{result1}
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappings(arg1 []models.TcpRouteMapping, arg2 models.RouterGroups, arg3 int) *routing_api.Error {
+	var arg1Copy []models.TcpRouteMapping
+	if arg1 != nil {
+		arg1Copy = make([]models.TcpRouteMapping, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.validateCreateTcpRouteMappingsMutex.Lock()
+	ret, specificReturn := fake.validateCreateTcpRouteMappingsReturnsOnCall[len(fake.validateCreateTcpRouteMappingsArgsForCall)]
+	fake.validateCreateTcpRouteMappingsArgsForCall = append(fake.validateCreateTcpRouteMappingsArgsForCall, struct {
+		arg1 []models.TcpRouteMapping
+		arg2 models.RouterGroups
+		arg3 int
+	}{arg1Copy, arg2, arg3})
+	stub := fake.ValidateCreateTcpRouteMappingsStub
+	fakeReturns := fake.validateCreateTcpRouteMappingsReturns
+	fake.recordInvocation("ValidateCreateTcpRouteMappings", []interface{}{arg1Copy, arg2, arg3})
+	fake.validateCreateTcpRouteMappingsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingsCallCount() int {
+	fake.validateCreateTcpRouteMappingsMutex.RLock()
+	defer fake.validateCreateTcpRouteMappingsMutex.RUnlock()
+	return len(fake.validateCreateTcpRouteMappingsArgsForCall)
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingsCalls(stub func([]models.TcpRouteMapping, models.RouterGroups, int) *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingsMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingsMutex.Unlock()
+	fake.ValidateCreateTcpRouteMappingsStub = stub
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingsArgsForCall(i int) ([]models.TcpRouteMapping, models.RouterGroups, int) {
+	fake.validateCreateTcpRouteMappingsMutex.RLock()
+	defer fake.validateCreateTcpRouteMappingsMutex.RUnlock()
+	argsForCall := fake.validateCreateTcpRouteMappingsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingsReturns(result1 *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingsMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingsMutex.Unlock()
+	fake.ValidateCreateTcpRouteMappingsStub = nil
+	fake.validateCreateTcpRouteMappingsReturns = struct {
+		result1 *routing_api.Error
+	}{result1}
+}
+
+func (fake *FakeRouteValidator) ValidateCreateTcpRouteMappingsReturnsOnCall(i int, result1 *routing_api.Error) {
+	fake.validateCreateTcpRouteMappingsMutex.Lock()
+	defer fake.validateCreateTcpRouteMappingsMutex.Unlock()
+	fake.ValidateCreateTcpRouteMappingsStub = nil
+	if fake.validateCreateTcpRouteMappingsReturnsOnCall == nil {
+		fake.validateCreateTcpRouteMappingsReturnsOnCall = make(map[int]struct {
+			result1 *routing_api.Error
+		})
+	}
+	fake.validateCreateTcpRouteMappingsReturnsOnCall[i] = struct {
 		result1 *routing_api.Error
 	}{result1}
 }
@@ -335,6 +418,8 @@ func (fake *FakeRouteValidator) Invocations() map[string][][]interface{} {
 	defer fake.validateCreateMutex.RUnlock()
 	fake.validateCreateTcpRouteMappingMutex.RLock()
 	defer fake.validateCreateTcpRouteMappingMutex.RUnlock()
+	fake.validateCreateTcpRouteMappingsMutex.RLock()
+	defer fake.validateCreateTcpRouteMappingsMutex.RUnlock()
 	fake.validateDeleteMutex.RLock()
 	defer fake.validateDeleteMutex.RUnlock()
 	fake.validateDeleteTcpRouteMappingMutex.RLock()

--- a/handlers/tcp_route_mappings_handler_test.go
+++ b/handlers/tcp_route_mappings_handler_test.go
@@ -92,6 +92,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 					})
 				})
 			})
+
 			Context("when an isolation segment is present", func() {
 				It("sets the isolation segment", func() {
 					tcpMapping := models.TcpRouteMapping{
@@ -178,7 +179,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 				var tcpMappings []models.TcpRouteMapping
 
 				BeforeEach(func() {
-					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
+					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{}, false, "")
 					tcpMappings = []models.TcpRouteMapping{tcpMapping}
 				})
 
@@ -315,7 +316,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 					tcpMappings  []models.TcpRouteMapping
 				)
 				BeforeEach(func() {
-					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{})
+					tcpMapping := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60001, "instanceId", nil, 60, models.ModificationTag{}, false, "")
 					tcpMappings = []models.TcpRouteMapping{tcpMapping}
 					currentCount = metrics.GetTokenErrors()
 					fakeClient.ValidateTokenReturns(errors.New("Not valid"))
@@ -347,8 +348,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			var tcpRoutes []models.TcpRouteMapping
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{}, false, "")
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{}, true, "alpn1,alpn2")
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadTcpRouteMappingsReturns(tcpRoutes, nil)
 			})
@@ -386,7 +387,9 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 									"index": 0
 								},
 								"ttl": 55,
-								"isolation_segment": ""
+								"isolation_segment": "",
+								"terminate_frontend_tls": true,
+								"alpns": "alpn1,alpn2"
 							}]`
 				Expect(responseRecorder.Body.String()).To(MatchJSON(expectedJson))
 			})
@@ -396,8 +399,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			var tcpRoutes []models.TcpRouteMapping
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{}, false, "")
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{}, true, "alpn1,alpn2")
 				mapping2.IsolationSegment = "is1"
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadFilteredTcpRouteMappingsReturns(tcpRoutes, nil)
@@ -444,7 +447,9 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 									"index": 0
 								},
 								"ttl": 55,
-								"isolation_segment": "is1"
+								"isolation_segment": "is1",
+								"terminate_frontend_tls": true,
+								"alpns": "alpn1,alpn2"
 							}]`
 				Expect(responseRecorder.Body.String()).To(MatchJSON(expectedJson))
 			})
@@ -488,7 +493,9 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 									"index": 0
 								},
 								"ttl": 55,
-								"isolation_segment": "is1"
+								"isolation_segment": "is1",
+								"terminate_frontend_tls": true,
+								"alpns": "alpn1,alpn2"
 							}]`
 				Expect(responseRecorder.Body.String()).To(MatchJSON(expectedJson))
 			})
@@ -498,8 +505,8 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			var tcpRoutes []models.TcpRouteMapping
 
 			BeforeEach(func() {
-				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{})
-				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{})
+				mapping1 := models.NewTcpRouteMapping("router-group-guid-001", 52000, "1.2.3.4", 60000, 60002, "instanceId", nil, 55, models.ModificationTag{}, false, "")
+				mapping2 := models.NewTcpRouteMapping("router-group-guid-001", 52001, "1.2.3.5", 60001, 60003, "instanceId", nil, 55, models.ModificationTag{}, true, "alpn1,alpn2")
 				mapping2.IsolationSegment = "is1"
 				tcpRoutes = []models.TcpRouteMapping{mapping1, mapping2}
 				database.ReadTcpRouteMappingsReturns(tcpRoutes, nil)
@@ -541,7 +548,9 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 									"index": 0
 								},
 								"ttl": 55,
-								"isolation_segment": "is1"
+								"isolation_segment": "is1",
+								"terminate_frontend_tls": true,
+								"alpns": "alpn1,alpn2"
 							}]`
 				Expect(responseRecorder.Body.String()).To(MatchJSON(expectedJson))
 			})
@@ -565,6 +574,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			BeforeEach(func() {
 				database.ReadTcpRouteMappingsReturns(nil, errors.New("something bad"))
 			})
+
 			It("returns internal server error", func() {
 				request = handlers.NewTestRequest("")
 				tcpRouteMappingsHandler.List(responseRecorder, request)
@@ -598,7 +608,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 			)
 
 			BeforeEach(func() {
-				tcpMapping = models.NewTcpRouteMapping("router-group-guid-002", 52001, "1.2.3.4", 60000, 60002, "instanceId", nil, 60, models.ModificationTag{})
+				tcpMapping = models.NewTcpRouteMapping("router-group-guid-002", 52001, "1.2.3.4", 60000, 60002, "instanceId", nil, 60, models.ModificationTag{}, false, "alpn1,alpn2")
 				tcpMappings = []models.TcpRouteMapping{tcpMapping}
 			})
 
@@ -647,6 +657,7 @@ var _ = Describe("TcpRouteMappingsHandler", func() {
 						"modification_tag":  map[string]interface{}{"guid": "", "index": float64(0)},
 						"ttl":               float64(60),
 						"isolation_segment": "",
+						"alpns":             "alpn1,alpn2",
 					}
 					logData := map[string][]interface{}{"tcp_mapping_deletion": {data}}
 

--- a/handlers/validator_test.go
+++ b/handlers/validator_test.go
@@ -26,377 +26,415 @@ var _ = Describe("Validator", func() {
 		routes = []models.Route{route}
 	})
 
-	Describe(".ValidateCreate", func() {
-		It("does not return an error if all route inputs are valid", func() {
-			err := validator.ValidateCreate(routes, maxTTL)
-			Expect(err).To(BeNil())
-		})
-
-		Context("when any route has an invalid value", func() {
-			BeforeEach(func() {
-				routes = append(routes, routes[0])
-			})
-
-			It("returns an error if any ttl is greater than max ttl", func() {
-				*routes[1].TTL = maxTTL + 1
-
+	Describe("Routes", func() {
+		Describe("ValidateCreate", func() {
+			It("does not return an error if all route inputs are valid", func() {
 				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal(fmt.Sprintf("Max ttl is %d", maxTTL)))
-			})
-
-			It("returns an error if any ttl is less than 1", func() {
-				*routes[1].TTL = 0
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Request requires a ttl greater than 0"))
-			})
-
-			It("returns an error if any request does not have a route", func() {
-				routes[0].Route = ""
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires a valid route"))
-			})
-
-			It("returns an error if any port is less than 1", func() {
-				routes[0].Port = 0
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires a port greater than 0"))
-			})
-
-			It("returns an error if the path contains invalid characters", func() {
-				routes[0].Route = "/foo/b ar"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Url cannot contain invalid characters"))
-			})
-
-			It("returns an error if the path is not valid", func() {
-				routes[0].Route = "/foo/bar%"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(ContainSubstring("invalid URL"))
-			})
-
-			It("returns an error if the path contains a question mark", func() {
-				routes[0].Route = "/foo/bar?a"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
-			})
-
-			It("returns an error if the path contains a hash mark", func() {
-				routes[0].Route = "/foo/bar#a"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
-			})
-
-			It("returns an error if the route service url is not https", func() {
-				routes[0].RouteServiceUrl = "http://my-rs.com/ab"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(Equal("Route service url must use HTTPS."))
-			})
-
-			It("returns an error if the route service url contains invalid characters", func() {
-				routes[0].RouteServiceUrl = "https://my-rs.com/a  b"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(Equal("Url cannot contain invalid characters"))
-			})
-
-			It("returns an error if the route service url host is not valid", func() {
-				routes[0].RouteServiceUrl = "https://my-rs%.com"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(ContainSubstring("invalid URL escape"))
-			})
-
-			It("returns an error if the route service url path is not valid", func() {
-				routes[0].RouteServiceUrl = "https://my-rs.com/ad%"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(ContainSubstring("invalid URL"))
-			})
-
-			It("returns an error if the route service url contains a question mark", func() {
-				routes[0].RouteServiceUrl = "https://foo/bar?a"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
-			})
-
-			It("returns an error if the route service url contains a hash mark", func() {
-				routes[0].RouteServiceUrl = "https://foo/bar#a"
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
-				Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
-			})
-
-			It("returns an error if any request does not have an IP", func() {
-				routes[1].IP = ""
-
-				err := validator.ValidateCreate(routes, maxTTL)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires an IP"))
-			})
-		})
-	})
-
-	Describe(".ValidateDelete", func() {
-		It("does not return an error if all route inputs are valid", func() {
-			err := validator.ValidateDelete(routes)
-			Expect(err).To(BeNil())
-		})
-
-		Context("when any route has an invalid value", func() {
-			BeforeEach(func() {
-				routes = append(routes, routes[0])
-			})
-
-			It("returns an error if any request does not have a route", func() {
-				routes[0].Route = ""
-
-				err := validator.ValidateDelete(routes)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires a valid route"))
-			})
-
-			It("returns an error if any port is less than 1", func() {
-				routes[0].Port = 0
-
-				err := validator.ValidateDelete(routes)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires a port greater than 0"))
-			})
-
-			It("returns an error if any request does not have an IP", func() {
-				routes[1].IP = ""
-
-				err := validator.ValidateDelete(routes)
-				Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
-				Expect(err.Error()).To(Equal("Each route request requires an IP"))
-			})
-		})
-	})
-
-	Describe("ValidateCreateTcpRouteMapping", func() {
-		var (
-			tcpMapping   models.TcpRouteMapping
-			routerGroups models.RouterGroups
-		)
-
-		BeforeEach(func() {
-			routerGroups = models.RouterGroups{
-				{
-					Guid:            DefaultRouterGroupGuid,
-					Name:            "default-tcp",
-					Type:            "tcp",
-					ReservablePorts: "1024-65535",
-				},
-			}
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{})
-		})
-
-		Context("when valid tcp mapping is passed", func() {
-			It("does not return error", func() {
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
 				Expect(err).To(BeNil())
 			})
-		})
 
-		Context("when invalid tcp route mappings are passed", func() {
-			Context("when there is no TLSPort provided", func() {
-				It("blows up when a backend port is zero", func() {
-					tcpMapping.HostPort = 0
-					err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+			Context("when any route has an invalid value", func() {
+				BeforeEach(func() {
+					routes = append(routes, routes[0])
+				})
+
+				It("returns an error if any ttl is greater than max ttl", func() {
+					*routes[1].TTL = maxTTL + 1
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal(fmt.Sprintf("Max ttl is %d", maxTTL)))
+				})
+
+				It("returns an error if any ttl is less than 1", func() {
+					*routes[1].TTL = 0
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Request requires a ttl greater than 0"))
+				})
+
+				It("returns an error if any request does not have a route", func() {
+					routes[0].Route = ""
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires a valid route"))
+				})
+
+				It("returns an error if any port is less than 1", func() {
+					routes[0].Port = 0
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires a port greater than 0"))
+				})
+
+				It("returns an error if the path contains invalid characters", func() {
+					routes[0].Route = "/foo/b ar"
+
+					err := validator.ValidateCreate(routes, maxTTL)
 					Expect(err).ToNot(BeNil())
-					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Url cannot contain invalid characters"))
+				})
+
+				It("returns an error if the path is not valid", func() {
+					routes[0].Route = "/foo/bar%"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(ContainSubstring("invalid URL"))
+				})
+
+				It("returns an error if the path contains a question mark", func() {
+					routes[0].Route = "/foo/bar?a"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
+				})
+
+				It("returns an error if the path contains a hash mark", func() {
+					routes[0].Route = "/foo/bar#a"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
+				})
+
+				It("returns an error if the route service url is not https", func() {
+					routes[0].RouteServiceUrl = "http://my-rs.com/ab"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(Equal("Route service url must use HTTPS."))
+				})
+
+				It("returns an error if the route service url contains invalid characters", func() {
+					routes[0].RouteServiceUrl = "https://my-rs.com/a  b"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(Equal("Url cannot contain invalid characters"))
+				})
+
+				It("returns an error if the route service url host is not valid", func() {
+					routes[0].RouteServiceUrl = "https://my-rs%.com"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(ContainSubstring("invalid URL escape"))
+				})
+
+				It("returns an error if the route service url path is not valid", func() {
+					routes[0].RouteServiceUrl = "https://my-rs.com/ad%"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(ContainSubstring("invalid URL"))
+				})
+
+				It("returns an error if the route service url contains a question mark", func() {
+					routes[0].RouteServiceUrl = "https://foo/bar?a"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
+				})
+
+				It("returns an error if the route service url contains a hash mark", func() {
+					routes[0].RouteServiceUrl = "https://foo/bar#a"
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.RouteServiceUrlInvalidError))
+					Expect(err.Error()).To(ContainSubstring("cannot contain any of [?, #]"))
+				})
+
+				It("returns an error if any request does not have an IP", func() {
+					routes[1].IP = ""
+
+					err := validator.ValidateCreate(routes, maxTTL)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires an IP"))
 				})
 			})
-			Context("When there is a TLSPort provided", func() {
+		})
+
+		Describe("ValidateDelete", func() {
+			It("does not return an error if all route inputs are valid", func() {
+				err := validator.ValidateDelete(routes)
+				Expect(err).To(BeNil())
+			})
+
+			Context("when any route has an invalid value", func() {
 				BeforeEach(func() {
-					tcpMapping.HostTLSPort = 6
+					routes = append(routes, routes[0])
 				})
-				Context("when host TLS port is > 65535", func() {
-					BeforeEach(func() {
-						tcpMapping.HostTLSPort = 65546
-					})
-					It("throws an error", func() {
-						err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+
+				It("returns an error if any request does not have a route", func() {
+					routes[0].Route = ""
+
+					err := validator.ValidateDelete(routes)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires a valid route"))
+				})
+
+				It("returns an error if any port is less than 1", func() {
+					routes[0].Port = 0
+
+					err := validator.ValidateDelete(routes)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires a port greater than 0"))
+				})
+
+				It("returns an error if any request does not have an IP", func() {
+					routes[1].IP = ""
+
+					err := validator.ValidateDelete(routes)
+					Expect(err.Type).To(Equal(routing_api.RouteInvalidError))
+					Expect(err.Error()).To(Equal("Each route request requires an IP"))
+				})
+			})
+		})
+	})
+
+	Describe("TcpRouteMappings", func() {
+		Describe("ValidateCreateTcpRouteMappings", func() {
+			var (
+				tcpMapping   models.TcpRouteMapping
+				routerGroups models.RouterGroups
+			)
+
+			BeforeEach(func() {
+				routerGroups = models.RouterGroups{
+					{
+						Guid:            DefaultRouterGroupGuid,
+						Name:            "default-tcp",
+						Type:            "tcp",
+						ReservablePorts: "1024-65535",
+					},
+				}
+				tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{}, false, "")
+			})
+
+			Context("when valid tcp mapping is passed", func() {
+				It("does not return error", func() {
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).To(BeNil())
+				})
+
+				It("does not return error when a second similar TcpRouteMapping is upserted", func() {
+					similarTcpRouteMappings := []models.TcpRouteMapping{
+						{TcpMappingEntity: models.TcpMappingEntity{
+							TerminateFrontendTLS: tcpMapping.TerminateFrontendTLS,
+						}},
+					}
+
+					err := validator.ValidateCreateTcpRouteMapping(tcpMapping, similarTcpRouteMappings, routerGroups, 120)
+					Expect(err).To(BeNil())
+				})
+			})
+
+			Context("when invalid tcp route mappings are passed", func() {
+				Context("when there is no TLSPort provided", func() {
+					It("blows up when a backend port is zero", func() {
+						tcpMapping.HostPort = 0
+						err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
 						Expect(err).ToNot(BeNil())
 						Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-						Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
+						Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
 					})
 				})
-				Context("when host port is zero", func() {
+
+				Context("When there is a TLSPort provided", func() {
 					BeforeEach(func() {
-						tcpMapping.HostPort = 0
+						tcpMapping.HostTLSPort = 6
 					})
-					It("does not error", func() {
-						err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-						Expect(err).ToNot(HaveOccurred())
+					Context("when host TLS port is > 65535", func() {
+						BeforeEach(func() {
+							tcpMapping.HostTLSPort = 65546
+						})
+						It("throws an error", func() {
+							err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+							Expect(err).ToNot(BeNil())
+							Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+							Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
+						})
 					})
+					Context("when host port is zero", func() {
+						BeforeEach(func() {
+							tcpMapping.HostPort = 0
+						})
+						It("does not error", func() {
+							err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+							Expect(err).ToNot(HaveOccurred())
+						})
+					})
+				})
+
+				It("blows up when a external port is zero", func() {
+					tcpMapping.ExternalPort = 0
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive external port"))
+				})
+
+				It("blows up when backend ip empty", func() {
+					tcpMapping.HostIP = ""
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty backend ip"))
+				})
+
+				It("blows up when group guid is empty", func() {
+					tcpMapping.RouterGroupGuid = ""
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty router group guid"))
+				})
+
+				It("blows up when group guid is unknown", func() {
+					tcpMapping.RouterGroupGuid = "unknown-router-group-guid"
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("router_group_guid: unknown-router-group-guid not found"))
+				})
+
+				It("blows up when TTL is greater than 120", func() {
+					*tcpMapping.TTL = 200
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires TTL to be less than or equal to 120"))
+				})
+
+				It("blows up when TTL is equal to 0", func() {
+					*tcpMapping.TTL = 0
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp route mapping requires a ttl greater than 0"))
+				})
+
+				It("blows up when TerminateFrontendTLS is disabled and ALPNs are defined", func() {
+					tcpMapping.ALPNs = "alpn1,alpn2"
+					err := validator.ValidateCreateTcpRouteMappings([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping can define ALPNs only when TerminateFrontendTLS is enabled."))
+				})
+
+				It("blows up when similar TcpRouteMappings have TerminateFrontendEnableds are different", func() {
+					tcpMapping.TerminateFrontendTLS = true
+					similarTcpRouteMappings := []models.TcpRouteMapping{
+						{TcpMappingEntity: models.TcpMappingEntity{
+							TerminateFrontendTLS: !tcpMapping.TerminateFrontendTLS,
+						}},
+					}
+
+					err := validator.ValidateCreateTcpRouteMapping(tcpMapping, similarTcpRouteMappings, routerGroups, 120)
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("terminate_frontend_tls: true not allowed"))
+				})
+			})
+		})
+
+		Describe("ValidateDeleteTcpRouteMapping", func() {
+			var (
+				tcpMapping models.TcpRouteMapping
+			)
+
+			BeforeEach(func() {
+				tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{}, false, "")
+			})
+
+			Context("when valid tcp mapping is passed", func() {
+				It("does not return error", func() {
+					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+					Expect(err).To(BeNil())
 				})
 			})
 
-			It("blows up when a external port is zero", func() {
-				tcpMapping.ExternalPort = 0
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive external port"))
-			})
+			Context("when invalid tcp route mappings are passed", func() {
+				Context("when there is no TLSPort provided", func() {
+					It("blows up when a backend port is zero", func() {
+						tcpMapping.HostPort = 0
+						err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+						Expect(err).ToNot(BeNil())
+						Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+						Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+					})
+				})
+				Context("When there is a TLSPort provided", func() {
+					BeforeEach(func() {
+						tcpMapping.HostTLSPort = 6
+					})
+					Context("when host TLS port is > 65535", func() {
+						BeforeEach(func() {
+							tcpMapping.HostTLSPort = 65546
+						})
+						It("throws an error", func() {
+							err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+							Expect(err).ToNot(BeNil())
+							Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+							Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
+						})
+					})
+					Context("when host port is zero", func() {
+						BeforeEach(func() {
+							tcpMapping.HostPort = 0
+						})
+						It("does not error", func() {
+							err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+							Expect(err).ToNot(HaveOccurred())
+						})
+					})
+				})
 
-			It("blows up when backend ip empty", func() {
-				tcpMapping.HostIP = ""
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty backend ip"))
-			})
-
-			It("blows up when group guid is empty", func() {
-				tcpMapping.RouterGroupGuid = ""
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty router group guid"))
-			})
-
-			It("blows up when group guid is unknown", func() {
-				tcpMapping.RouterGroupGuid = "unknown-router-group-guid"
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("router_group_guid: unknown-router-group-guid not found"))
-			})
-
-			It("blows up when TTL is greater than 120", func() {
-				*tcpMapping.TTL = 200
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires TTL to be less than or equal to 120"))
-			})
-
-			It("blows up when TTL is equal to 0", func() {
-				*tcpMapping.TTL = 0
-				err := validator.ValidateCreateTcpRouteMapping([]models.TcpRouteMapping{tcpMapping}, routerGroups, 120)
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp route mapping requires a ttl greater than 0"))
-			})
-		})
-	})
-
-	Describe("ValidateDeleteTcpRouteMapping", func() {
-		var (
-			tcpMapping models.TcpRouteMapping
-		)
-
-		BeforeEach(func() {
-			tcpMapping = models.NewTcpRouteMapping(DefaultRouterGroupGuid, 52000, "1.2.3.4", 60000, 0, "instanceId", nil, 60, models.ModificationTag{})
-		})
-
-		Context("when valid tcp mapping is passed", func() {
-			It("does not return error", func() {
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).To(BeNil())
-			})
-		})
-
-		Context("when invalid tcp route mappings are passed", func() {
-			Context("when there is no TLSPort provided", func() {
-				It("blows up when a backend port is zero", func() {
-					tcpMapping.HostPort = 0
+				It("blows up when a external port is zero", func() {
+					tcpMapping.ExternalPort = 0
 					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
 					Expect(err).ToNot(BeNil())
 					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive backend port"))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive external port"))
 				})
-			})
-			Context("When there is a TLSPort provided", func() {
-				BeforeEach(func() {
-					tcpMapping.HostTLSPort = 6
+
+				It("blows up when backend ip empty", func() {
+					tcpMapping.HostIP = ""
+					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty backend ip"))
 				})
-				Context("when host TLS port is > 65535", func() {
-					BeforeEach(func() {
-						tcpMapping.HostTLSPort = 65546
-					})
-					It("throws an error", func() {
-						err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-						Expect(err).ToNot(BeNil())
-						Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-						Expect(err.Error()).To(ContainSubstring("Each tcp mapping with a backend TLS port requires that port to be less than or equal to 65535"))
-					})
+
+				It("blows up when group guid is empty", func() {
+					tcpMapping.RouterGroupGuid = ""
+					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+					Expect(err).ToNot(BeNil())
+					Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
+					Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty router group guid"))
 				})
-				Context("when host port is zero", func() {
-					BeforeEach(func() {
-						tcpMapping.HostPort = 0
-					})
-					It("does not error", func() {
-						err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-						Expect(err).ToNot(HaveOccurred())
-					})
+
+				It("does not blow up when group guid is unknown", func() {
+					tcpMapping.RouterGroupGuid = "unknown-router-group-guid"
+					err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
+					Expect(err).To(BeNil())
 				})
-			})
-
-			It("blows up when a external port is zero", func() {
-				tcpMapping.ExternalPort = 0
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a positive external port"))
-			})
-
-			It("blows up when backend ip empty", func() {
-				tcpMapping.HostIP = ""
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty backend ip"))
-			})
-
-			It("blows up when group guid is empty", func() {
-				tcpMapping.RouterGroupGuid = ""
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).ToNot(BeNil())
-				Expect(err.Type).To(Equal(routing_api.TcpRouteMappingInvalidError))
-				Expect(err.Error()).To(ContainSubstring("Each tcp mapping requires a non empty router group guid"))
-			})
-
-			It("does not blow up when group guid is unknown", func() {
-				tcpMapping.RouterGroupGuid = "unknown-router-group-guid"
-				err := validator.ValidateDeleteTcpRouteMapping([]models.TcpRouteMapping{tcpMapping})
-				Expect(err).To(BeNil())
 			})
 		})
 	})

--- a/migration/V9_terminate_frontend_tls.go
+++ b/migration/V9_terminate_frontend_tls.go
@@ -1,0 +1,22 @@
+package migration
+
+import (
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/models"
+)
+
+type V9TerminateFrontendTLS struct{}
+
+var _ Migration = new(V9TerminateFrontendTLS)
+
+func NewV9TerminateFrontendTLS() *V9TerminateFrontendTLS {
+	return &V9TerminateFrontendTLS{}
+}
+
+func (v *V9TerminateFrontendTLS) Version() int {
+	return 9
+}
+
+func (v *V9TerminateFrontendTLS) Run(sqlDB *db.SqlDB) error {
+	return sqlDB.Client.AutoMigrate(&models.TcpRouteMapping{})
+}

--- a/migration/V9_terminate_frontend_tls_test.go
+++ b/migration/V9_terminate_frontend_tls_test.go
@@ -1,0 +1,155 @@
+package migration_test
+
+import (
+	"time"
+
+	"code.cloudfoundry.org/routing-api/cmd/routing-api/testrunner"
+	"code.cloudfoundry.org/routing-api/db"
+	"code.cloudfoundry.org/routing-api/migration"
+	v7 "code.cloudfoundry.org/routing-api/migration/v7"
+	"code.cloudfoundry.org/routing-api/models"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("V9TerminateFrontendTLS", func() {
+	var (
+		sqlDB       *db.SqlDB
+		dbAllocator testrunner.DbAllocator
+	)
+
+	BeforeEach(func() {
+		dbAllocator = testrunner.NewDbAllocator()
+		sqlCfg, err := dbAllocator.Create()
+		Expect(err).NotTo(HaveOccurred())
+
+		sqlDB, err = db.NewSqlDB(sqlCfg)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		err := dbAllocator.Delete()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	runTests := func() {
+		Context("during migration", func() {
+			It("allows the migration to occur", func() {
+				v9Migration := migration.NewV9TerminateFrontendTLS()
+				err := v9Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				routes, err := sqlDB.ReadTcpRouteMappings()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+				Expect(routes[0].TerminateFrontendTLS).To(Equal(false))
+				Expect(routes[0].ALPNs).To(Equal(""))
+			})
+		})
+		Context("After migration", func() {
+			var tcpRoute1 models.TcpRouteMapping
+
+			BeforeEach(func() {
+				v9Migration := migration.NewV9TerminateFrontendTLS()
+				err := v9Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 = models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-1"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid: "test1",
+						HostPort:        80,
+						HostTLSPort:     443,
+						HostIP:          "1.2.3.4",
+						InstanceId:      "instanceId1",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+
+						ModificationTag:      models.ModificationTag{},
+						TTL:                  nil,
+						IsolationSegment:     "",
+						TerminateFrontendTLS: false,
+						ALPNs:                "",
+					},
+				}
+			})
+
+			It("expect no error to occur", func() {
+				_, err := sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	}
+
+	Describe("Version", func() {
+		It("returns 9 for the version", func() {
+			v9Migration := migration.NewV9TerminateFrontendTLS()
+			Expect(v9Migration.Version()).To(Equal(9))
+		})
+	})
+
+	Describe("Run", func() {
+		Context("when there are existing tables with the old tcp_route model", func() {
+			BeforeEach(func() {
+				err := sqlDB.Client.AutoMigrate(&v7.RouterGroupDB{}, &v7.TcpRouteMapping{}, &v7.Route{})
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := v7.TcpRouteMapping{
+					Model:     v7.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: v7.TcpMappingEntity{
+						RouterGroupGuid: "test0",
+						HostPort:        80,
+						HostIP:          "1.2.3.4",
+						ExternalPort:    80,
+						SniHostname:     &sniHostname1,
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+
+				v9Migration := migration.NewV9TerminateFrontendTLS()
+				err = v9Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+			})
+			runTests()
+		})
+
+		Context("when the tables are newly created (by V0 init migration)", func() {
+			BeforeEach(func() {
+				v0Migration := migration.NewV0InitMigration()
+				err := v0Migration.Run(sqlDB)
+				Expect(err).ToNot(HaveOccurred())
+
+				sniHostname1 := "sniHostname1"
+				tcpRoute1 := models.TcpRouteMapping{
+					Model:     models.Model{Guid: "guid-0"},
+					ExpiresAt: time.Now().Add(1 * time.Hour),
+					TcpMappingEntity: models.TcpMappingEntity{
+						RouterGroupGuid:      "test0",
+						HostPort:             80,
+						HostTLSPort:          100,
+						HostIP:               "1.2.3.4",
+						SniHostname:          &sniHostname1,
+						InstanceId:           "",
+						ExternalPort:         80,
+						ModificationTag:      models.ModificationTag{},
+						TTL:                  nil,
+						IsolationSegment:     "",
+						TerminateFrontendTLS: false,
+						ALPNs:                "",
+					},
+				}
+
+				_, err = sqlDB.Client.Create(&tcpRoute1)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			runTests()
+		})
+	})
+})

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -64,7 +64,7 @@ type Migration interface {
 }
 
 func InitializeMigrations() []Migration {
-	migrations := []Migration{}
+	migrations := make([]Migration, 0)
 	var migration Migration
 
 	migration = NewV0InitMigration()
@@ -89,6 +89,9 @@ func InitializeMigrations() []Migration {
 	migrations = append(migrations, migration)
 
 	migration = NewV8HostTLSPortTCPDefaultZero()
+	migrations = append(migrations, migration)
+
+	migration = NewV9TerminateFrontendTLS()
 	migrations = append(migrations, migration)
 
 	return migrations

--- a/migration/migration_test.go
+++ b/migration/migration_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Migration", func() {
 				done := make(chan struct{})
 				defer close(done)
 				migrations := migration.InitializeMigrations()
-				Expect(migrations).To(HaveLen(8))
+				Expect(migrations).To(HaveLen(9))
 
 				Expect(migrations[0]).To(BeAssignableToTypeOf(new(migration.V0InitMigration)))
 				Expect(migrations[1]).To(BeAssignableToTypeOf(new(migration.V2UpdateRgMigration)))
@@ -52,6 +52,8 @@ var _ = Describe("Migration", func() {
 				Expect(migrations[4]).To(BeAssignableToTypeOf(new(migration.V5SniHostnameMigration)))
 				Expect(migrations[5]).To(BeAssignableToTypeOf(new(migration.V6TCPTLSRoutes)))
 				Expect(migrations[6]).To(BeAssignableToTypeOf(new(migration.V7TCPTLSRoutes)))
+				Expect(migrations[7]).To(BeAssignableToTypeOf(new(migration.V8HostTLSPortTCPDefaultZero)))
+				Expect(migrations[8]).To(BeAssignableToTypeOf(new(migration.V9TerminateFrontendTLS)))
 			})
 		})
 

--- a/models/models_test.go
+++ b/models/models_test.go
@@ -426,7 +426,7 @@ var _ = Describe("Models", func() {
 		BeforeEach(func() {
 			tag, err := NewModificationTag()
 			Expect(err).ToNot(HaveOccurred())
-			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag)
+			route = NewTcpRouteMapping("router-group-1", 60000, "2.2.2.2", 64000, 64001, "instance-id", pointertoString("sni-hostname"), 66, tag, false, "")
 		})
 
 		Describe("SetDefaults", func() {

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -33,7 +33,8 @@ type TcpMappingEntity struct {
 	TTL                  *int   `json:"ttl,omitempty"`
 	IsolationSegment     string `json:"isolation_segment"`
 	TerminateFrontendTLS bool   `gorm:"default:false" json:"terminate_frontend_tls,omitempty"`
-	ALPNs                string `json:"alpns,omitempty"`
+	// alpns is a csv value
+	ALPNs string `json:"alpns,omitempty"`
 }
 
 func (TcpRouteMapping) TableName() string {

--- a/models/tcp_route.go
+++ b/models/tcp_route.go
@@ -27,11 +27,13 @@ type TcpMappingEntity struct {
 	// We don't add uniqueness on InstanceId so that if a route is attempted to be created with the same detals but
 	// different InstanceId, we fail uniqueness and prevent stale/duplicate routes. If this fails a route, the
 	// TTL on the old record should expire + allow the new route to be created eventually.
-	InstanceId       string `gorm:"null; default:null;" json:"instance_id"`
-	ExternalPort     uint16 `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
-	ModificationTag  `json:"modification_tag"`
-	TTL              *int   `json:"ttl,omitempty"`
-	IsolationSegment string `json:"isolation_segment"`
+	InstanceId           string `gorm:"null; default:null;" json:"instance_id"`
+	ExternalPort         uint16 `gorm:"not null; unique_index:idx_tcp_route; type: int" json:"port"`
+	ModificationTag      `json:"modification_tag"`
+	TTL                  *int   `json:"ttl,omitempty"`
+	IsolationSegment     string `json:"isolation_segment"`
+	TerminateFrontendTLS bool   `gorm:"default:false" json:"terminate_frontend_tls,omitempty"`
+	ALPNs                string `json:"alpns,omitempty"`
 }
 
 func (TcpRouteMapping) TableName() string {
@@ -62,18 +64,22 @@ func NewTcpRouteMapping(
 	sniHostname *string,
 	ttl int,
 	modTag ModificationTag,
+	terminateFrontendTLS bool,
+	alpns string,
 ) TcpRouteMapping {
 	mapping := TcpRouteMapping{
 		TcpMappingEntity: TcpMappingEntity{
-			RouterGroupGuid: routerGroupGuid,
-			ExternalPort:    externalPort,
-			SniHostname:     sniHostname,
-			InstanceId:      instanceId,
-			HostPort:        hostPort,
-			HostTLSPort:     hostTlsPort,
-			HostIP:          hostIP,
-			TTL:             &ttl,
-			ModificationTag: modTag,
+			RouterGroupGuid:      routerGroupGuid,
+			ExternalPort:         externalPort,
+			SniHostname:          sniHostname,
+			InstanceId:           instanceId,
+			HostPort:             hostPort,
+			HostTLSPort:          hostTlsPort,
+			HostIP:               hostIP,
+			TTL:                  &ttl,
+			ModificationTag:      modTag,
+			TerminateFrontendTLS: terminateFrontendTLS,
+			ALPNs:                alpns,
 		},
 	}
 	return mapping

--- a/models/tcp_route_test.go
+++ b/models/tcp_route_test.go
@@ -17,7 +17,7 @@ var _ = Describe("TCP Route", func() {
 		var sniHostNamePtr *string
 
 		JustBeforeEach(func() {
-			tcpRouteMapping = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr, 5, models.ModificationTag{})
+			tcpRouteMapping = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr, 5, models.ModificationTag{}, false, "")
 		})
 		Describe("SNI Hostname", func() {
 			Context("when the SNI hostname is nil", func() {
@@ -68,7 +68,7 @@ var _ = Describe("TCP Route", func() {
 			})
 
 			JustBeforeEach(func() {
-				tcpRouteMapping2 = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr2, 5, models.ModificationTag{})
+				tcpRouteMapping2 = models.NewTcpRouteMapping("a-guid", 1234, "hostIp", 5678, 8765, "", sniHostNamePtr2, 5, models.ModificationTag{}, false, "")
 			})
 
 			Context("when two routes have the same SNIHostName value", func() {
@@ -103,6 +103,32 @@ var _ = Describe("TCP Route", func() {
 				It("doesn't match", func() {
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeFalse())
 					Expect(tcpRouteMapping2.Matches(tcpRouteMapping)).To(BeFalse())
+				})
+			})
+
+			Context("when two routes are equal and TerminateFrontendTLS are different", func() {
+				JustBeforeEach(func() {
+					tcpRouteMapping2.SniHostname = tcpRouteMapping.SniHostname
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+
+				It("matches()", func() {
+					tcpRouteMapping.TerminateFrontendTLS = false
+					tcpRouteMapping2.TerminateFrontendTLS = true
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+			})
+
+			Context("when two routes are equal and ALPNs are different", func() {
+				JustBeforeEach(func() {
+					tcpRouteMapping2.SniHostname = tcpRouteMapping.SniHostname
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+				})
+
+				It("matches()", func() {
+					tcpRouteMapping.ALPNs = ""
+					tcpRouteMapping2.ALPNs = "alpn1,alpn2"
+					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
 				})
 			})
 		})

--- a/models/tcp_route_test.go
+++ b/models/tcp_route_test.go
@@ -110,11 +110,12 @@ var _ = Describe("TCP Route", func() {
 				JustBeforeEach(func() {
 					tcpRouteMapping2.SniHostname = tcpRouteMapping.SniHostname
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+
+					tcpRouteMapping.TerminateFrontendTLS = false
+					tcpRouteMapping2.TerminateFrontendTLS = true
 				})
 
 				It("matches()", func() {
-					tcpRouteMapping.TerminateFrontendTLS = false
-					tcpRouteMapping2.TerminateFrontendTLS = true
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
 				})
 			})
@@ -123,11 +124,12 @@ var _ = Describe("TCP Route", func() {
 				JustBeforeEach(func() {
 					tcpRouteMapping2.SniHostname = tcpRouteMapping.SniHostname
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
+
+					tcpRouteMapping.ALPNs = ""
+					tcpRouteMapping2.ALPNs = "alpn1,alpn2"
 				})
 
 				It("matches()", func() {
-					tcpRouteMapping.ALPNs = ""
-					tcpRouteMapping2.ALPNs = "alpn1,alpn2"
 					Expect(tcpRouteMapping.Matches(tcpRouteMapping2)).To(BeTrue())
 				})
 			})


### PR DESCRIPTION
Resolves:
This is a request from Broadcom Engineering team to fix it and is recorded under TNZ-48493

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->
This commit introduces comprehensive TLS termination capabilities for TCP route mappings in the Cloud Foundry routing API, enabling secure end-to-end TLS connections with Application Layer Protocol Negotiation (ALPN) support.

Key Changes:
- Add TerminateFrontendTLS boolean field to TcpRouteMapping model
- Add ALPNs string field to support Application Layer Protocol Negotiation
- Implement V9 database migration for new TLS termination fields
- Update NewTcpRouteMapping constructor to accept TLS parameters
- Add validation logic to ensure ALPNs are only defined when TLS termination is enabled
- Update all test files to accommodate new constructor signature
- Enhance TCP route matching logic to include TLS termination fields
- Add comprehensive test coverage for new TLS functionality

Database Changes:
- New V9 migration adds TerminateFrontendTLS (bool, default: false) and ALPNs (string) columns
- Migration supports both existing v7 schema and fresh V0 initialization
- Backward compatible with existing TCP route mappings

API Enhancements:
- TCP route mapping responses now include terminate_frontend_tls and alpns fields
- Validation ensures ALPNs can only be specified when TerminateFrontendTLS is true
- Maintains backward compatibility with existing API consumers

Testing:
- Comprehensive test suite for V9 migration covering both upgrade and fresh install scenarios
- Updated all existing TCP route mapping tests to use new constructor signature
- Added validation tests for ALPN/TLS termination field combinations
- Enhanced route matching tests to verify TLS field equality

This feature enables secure TCP routing with TLS termination at the router level, supporting modern TLS protocols and ALPN negotiation for improved security and protocol flexibility in Cloud Foundry environments.


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
